### PR TITLE
Reading from file objects

### DIFF
--- a/goenrich/obo.py
+++ b/goenrich/obo.py
@@ -44,7 +44,15 @@ _filename = 'db/go-basic.obo'
 
 def ontology(filename):
     O = nx.DiGraph()
-    with open(filename) as f:
+
+    if isinstance(filename, str):
+        f = open(filename)
+        we_opened_file = True
+    else:
+        f = filename
+        we_opened_file = False
+
+    try:
         tokens = _tokenize(f)
         terms = _filter_terms(tokens)
         entries = _parse_terms(terms)
@@ -53,6 +61,10 @@ def ontology(filename):
         O.add_edges_from(itertools.chain.from_iterable(edges))
         O.graph['roots'] = {data['name'] : n for n, data in O.node.items()
                 if data['name'] == data['namespace']}
+    finally:
+        if we_opened_file:
+            f.close()
+
     for root in O.graph['roots'].values():
         for n, depth in nx.shortest_path_length(O, root).items():
             node = O.node[n]

--- a/goenrich/read.py
+++ b/goenrich/read.py
@@ -46,9 +46,8 @@ def gene2go(filename, experimental=False, tax_id=9606, **kwds):
     :param experimental: use only experimentally validated annotations
     :param tax_id: filter according to taxon
     """
-    defaults = {'compression' : 'gzip',
-            'comment' : '#',
-            'names' : GENE2GO_COLUMNS }
+    defaults = {'comment': '#',
+                'names': GENE2GO_COLUMNS}
     defaults.update(kwds)
     result = pd.read_table(filename, **defaults)
     

--- a/goenrich/tests/test_reading.py
+++ b/goenrich/tests/test_reading.py
@@ -9,6 +9,7 @@ class TestRead(unittest.TestCase):
     def test_ontology_from_file_obj(self):
         with open('db/go-basic.obo') as f:
             G = goenrich.obo.ontology(f)
+            self.assertFalse(f.closed)
 
     def test_goa(self):
         background = goenrich.read.goa('db/gene_association.goa_ref_human.gz')
@@ -16,6 +17,7 @@ class TestRead(unittest.TestCase):
     def test_goa_from_file_obj(self):
         with gzip.GzipFile('db/gene_association.goa_ref_human.gz') as f:
             background = goenrich.read.goa(f)
+            self.assertFalse(f.closed)
 
     def test_gene2go(self):
         background = goenrich.read.gene2go('db/gene2go.gz')
@@ -23,6 +25,7 @@ class TestRead(unittest.TestCase):
     def test_gene2go_from_file_obj(self):
         with gzip.GzipFile('db/gene2go.gz') as f:
             background = goenrich.read.gene2go(f)
+            self.assertFalse(f.closed)
 
 if __name__ == '__main__':
     unittest.main()

--- a/goenrich/tests/test_reading.py
+++ b/goenrich/tests/test_reading.py
@@ -1,16 +1,28 @@
 import unittest
-
+import gzip
 import goenrich
 
 class TestRead(unittest.TestCase):
     def test_ontology(self):
         G = goenrich.obo.ontology('db/go-basic.obo')
 
+    def test_ontology_from_file_obj(self):
+        with open('db/go-basic.obo') as f:
+            G = goenrich.obo.ontology(f)
+
     def test_goa(self):
         background = goenrich.read.goa('db/gene_association.goa_ref_human.gz')
 
+    def test_goa_from_file_obj(self):
+        with gzip.GzipFile('db/gene_association.goa_ref_human.gz') as f:
+            background = goenrich.read.goa(f)
+
     def test_gene2go(self):
         background = goenrich.read.gene2go('db/gene2go.gz')
+
+    def test_gene2go_from_file_obj(self):
+        with gzip.GzipFile('db/gene2go.gz') as f:
+            background = goenrich.read.gene2go(f)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fairly self-descriptory PR.
Allows one to pass a file object instead of filename to the parsing methods.
