### PR TITLE
Compatibility with Networkx 2.0

### DIFF
--- a/goenrich/enrich.py
+++ b/goenrich/enrich.py
@@ -43,7 +43,7 @@ def analyze(O, query, background_attribute, **kwargs):
             if term in G:
                 G.node[term].update({'name' : node['name'], 'x' : x,
                     'q' : q, 'n' : n, 'significant' : rej})
-        G.reverse(copy=False)
+        G = G.reverse(copy=False)
         goenrich.export.to_graphviz(G, **options)
     return df
     

--- a/goenrich/export.py
+++ b/goenrich/export.py
@@ -39,7 +39,8 @@ def to_graphviz(G, gvfile, graph_label='', **kwargs):
         else:
             attr['color'] = 'black'
             attr['label'] = """{name}""".format(name=node['name'])
-        G.node[n] = attr
+        G.node[n].clear()
+        G.node[n].update(attr)
 
     A = nx.drawing.nx_agraph.to_agraph(G)
     A.graph_attr['label'] = graph_label

--- a/goenrich/obo.py
+++ b/goenrich/obo.py
@@ -72,5 +72,5 @@ def ontology(file):
         for n, depth in nx.shortest_path_length(O, root).items():
             node = O.node[n]
             node['depth'] = min(depth, node.get('depth', float('inf')))
-    O.reverse(copy=False)
+    O = O.reverse(copy=False)
     return O

--- a/goenrich/tests/test_enrichment.py
+++ b/goenrich/tests/test_enrichment.py
@@ -1,9 +1,7 @@
-import pkg_resources
 import unittest
 import subprocess
 import goenrich
 import networkx
-import pandas as pd
 
 class TestGoenrich(unittest.TestCase):
 

--- a/goenrich/tests/test_enrichment.py
+++ b/goenrich/tests/test_enrichment.py
@@ -1,7 +1,9 @@
+import pkg_resources
 import unittest
 import subprocess
 import goenrich
 import networkx
+import pandas as pd
 
 class TestGoenrich(unittest.TestCase):
 
@@ -14,12 +16,14 @@ class TestGoenrich(unittest.TestCase):
         query = gene2go['GeneID'].unique()[:20]
         try:
             import pygraphviz
-            goenrich.enrich.analyze(O, query, background_attribute, gvfile='test.dot')
+            df = goenrich.enrich.analyze(O, query, background_attribute, gvfile='test.dot')
             subprocess.check_call(['dot', '-Tpng', 'test.dot', '-o', 'test.png'])
             subprocess.check_call(['rm', 'test.dot', 'test.png'])
         except ImportError:
-            goenrich.enrich.analyze(O, query, background_attribute)
+            df = goenrich.enrich.analyze(O, query, background_attribute)
             print('pygraphviz could not be imported')
+        self.assertEqual(len(df.query('q<0.05')), 10)
+
 
     def test_pval_correctness(self):
         O = networkx.DiGraph()

--- a/goenrich/tests/test_ontologies/goslim_generic.obo
+++ b/goenrich/tests/test_ontologies/goslim_generic.obo
@@ -1,0 +1,4124 @@
+format-version: 1.2
+subsetdef: goantislim_grouping "Grouping classes that can be excluded"
+subsetdef: gocheck_do_not_annotate "Term not to be used for direct annotation"
+subsetdef: gocheck_do_not_manually_annotate "Term not to be used for direct manual annotation"
+subsetdef: goslim_agr "AGR slim"
+subsetdef: goslim_aspergillus "Aspergillus GO slim"
+subsetdef: goslim_candida "Candida GO slim"
+subsetdef: goslim_chembl "ChEMBL protein targets summary"
+subsetdef: goslim_generic "Generic GO slim"
+subsetdef: goslim_goa "GOA and proteome slim"
+subsetdef: goslim_metagenomics "Metagenomics GO slim"
+subsetdef: goslim_mouse "Mouse GO slim"
+subsetdef: goslim_pir "PIR GO slim"
+subsetdef: goslim_plant "Plant GO slim"
+subsetdef: goslim_pombe "Fission yeast GO slim"
+subsetdef: goslim_synapse "synapse GO slim"
+subsetdef: goslim_virus "Viral GO slim"
+subsetdef: goslim_yeast "Yeast GO slim"
+subsetdef: gosubset_prok "Prokaryotic GO subset"
+subsetdef: mf_needs_review "Catalytic activity terms in need of attention"
+subsetdef: termgenie_unvetted "Terms created by TermGenie that do not follow a template and require additional vetting by editors"
+subsetdef: virus_checked "Viral overhaul terms"
+synonymtypedef: syngo_official_label "label approved by the SynGO project"
+synonymtypedef: systematic_synonym "Systematic synonym" EXACT
+ontology: go/subsets/goslim_generic
+
+[Term]
+id: GO:0000003
+name: reproduction
+namespace: biological_process
+alt_id: GO:0019952
+alt_id: GO:0050876
+def: "The production of new individuals that contain some portion of genetic material inherited from one or more parent organisms." [GOC:go_curators, GOC:isa_complete, GOC:jl, ISBN:0198506732]
+subset: goslim_agr
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "reproductive physiological process" EXACT []
+xref: Wikipedia:Reproduction
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0000228
+name: nuclear chromosome
+namespace: cellular_component
+def: "A chromosome that encodes the nuclear genome and is found in the nucleus of a eukaryotic cell during the cell cycle phases when the nucleus is intact." [GOC:dph, GOC:mah]
+subset: goslim_chembl
+subset: goslim_generic
+synonym: "nuclear interphase chromosome" NARROW []
+is_a: GO:0005694 ! chromosome
+intersection_of: GO:0005694 ! chromosome
+intersection_of: part_of GO:0005634 ! nucleus
+relationship: part_of GO:0005634 ! nucleus
+
+[Term]
+id: GO:0000229
+name: cytoplasmic chromosome
+namespace: cellular_component
+def: "A chromosome found in the cytoplasm." [GOC:mah]
+subset: goslim_chembl
+subset: goslim_generic
+subset: gosubset_prok
+synonym: "cytoplasmic interphase chromosome" NARROW []
+is_a: GO:0005694 ! chromosome
+intersection_of: GO:0005694 ! chromosome
+intersection_of: part_of GO:0005737 ! cytoplasm
+relationship: part_of GO:0005737 ! cytoplasm
+
+[Term]
+id: GO:0000278
+name: mitotic cell cycle
+namespace: biological_process
+alt_id: GO:0007067
+def: "Progression through the phases of the mitotic cell cycle, the most common eukaryotic cell cycle, which canonically comprises four successive phases called G1, S, G2, and M and includes replication of the genome and the subsequent segregation of chromosomes into daughter cells. In some variant cell cycles nuclear replication or nuclear division may not be followed by cell division, or G1 and G2 phases may be absent." [GOC:mah, ISBN:0815316194, Reactome:69278]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+synonym: "mitosis" RELATED []
+xref: Reactome:REACT_100451 "Cell Cycle, Mitotic, Taeniopygia guttata"
+xref: Reactome:REACT_104035 "Cell Cycle, Mitotic, Sus scrofa"
+xref: Reactome:REACT_104195 "Cell Cycle, Mitotic, Canis familiaris"
+xref: Reactome:REACT_105856 "Cell Cycle, Mitotic, Danio rerio"
+xref: Reactome:REACT_108233 "Cell Cycle, Mitotic, Saccharomyces cerevisiae"
+xref: Reactome:REACT_152 "Cell Cycle, Mitotic, Homo sapiens"
+xref: Reactome:REACT_28464 "Cell Cycle, Mitotic, Xenopus tropicalis"
+xref: Reactome:REACT_28953 "Cell Cycle, Mitotic, Bos taurus"
+xref: Reactome:REACT_33388 "Cell Cycle, Mitotic, Rattus norvegicus"
+xref: Reactome:REACT_53493 "Cell Cycle, Mitotic, Plasmodium falciparum"
+xref: Reactome:REACT_79085 "Cell Cycle, Mitotic, Schizosaccharomyces pombe"
+xref: Reactome:REACT_84794 "Cell Cycle, Mitotic, Caenorhabditis elegans"
+xref: Reactome:REACT_85137 "Cell Cycle, Mitotic, Gallus gallus"
+xref: Reactome:REACT_85950 "Cell Cycle, Mitotic, Arabidopsis thaliana"
+xref: Reactome:REACT_90332 "Cell Cycle, Mitotic, Mus musculus"
+xref: Reactome:REACT_90846 "Cell Cycle, Mitotic, Oryza sativa"
+xref: Reactome:REACT_96281 "Cell Cycle, Mitotic, Drosophila melanogaster"
+xref: Reactome:REACT_97744 "Cell Cycle, Mitotic, Dictyostelium discoideum"
+xref: Reactome:REACT_98208 "Cell Cycle, Mitotic, Mycobacterium tuberculosis"
+xref: Wikipedia:Mitosis
+is_a: GO:0007049 ! cell cycle
+intersection_of: GO:0007049 ! cell cycle
+intersection_of: has_part GO:0140014 ! mitotic nuclear division
+relationship: has_part GO:0140014 ! mitotic nuclear division
+
+[Term]
+id: GO:0000902
+name: cell morphogenesis
+namespace: biological_process
+alt_id: GO:0007148
+alt_id: GO:0045790
+alt_id: GO:0045791
+def: "The developmental process in which the size or shape of a cell is generated and organized." [GOC:clt, GOC:dph, GOC:go_curators, GOC:tb]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "cellular morphogenesis" EXACT []
+is_a: GO:0008150 ! biological_process
+relationship: part_of GO:0048856 ! anatomical structure development
+
+[Term]
+id: GO:0000988
+name: transcription factor activity, protein binding
+namespace: molecular_function
+def: "Interacting selectively and non-covalently with any protein or protein complex (a complex of two or more proteins that may include other nonprotein molecules), in order to modulate transcription. A protein binding transcription factor may or may not also interact with the template nucleic acid (either DNA or RNA) as well." [GOC:txnOH]
+comment: Note that this term is in the subset of terms that should not be used for direct gene product annotation. This term does not provide specificity with respect to the type of protein binding, e.g. transcription factor binding or RNA polymerase binding. Please use a child term that provides that specificity or, if no appropriate child term exists, please request a new term. Direct annotations to this term may be amended during annotation QC.
+subset: gocheck_do_not_manually_annotate
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_yeast
+synonym: "protein binding transcription factor activity" EXACT []
+synonym: "transcription factor activity" BROAD []
+is_a: GO:0003674 ! molecular_function
+relationship: has_part GO:0003674 ! molecular_function
+relationship: part_of GO:0008150 ! biological_process
+created_by: kchris
+creation_date: 2010-08-10T04:03:22Z
+
+[Term]
+id: GO:0001071
+name: nucleic acid binding transcription factor activity
+namespace: molecular_function
+def: "Interacting selectively and non-covalently with a DNA or RNA sequence in order to modulate transcription. The transcription factor may or may not also interact selectively with a protein or macromolecular complex." [GOC:txnOH]
+comment: Note that this term is in the subset of terms that should not be used for direct gene product annotation. This term does not provide specificity with respect to the type of nucleic acid binding, e.g. RNA or DNA. Please use a child term that provides that specificity or, if no appropriate child term exists, please request a new term. Direct annotations to this term may be amended during annotation QC.
+subset: gocheck_do_not_manually_annotate
+subset: goslim_agr
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_yeast
+synonym: "transcription factor activity" BROAD []
+is_a: GO:0003674 ! molecular_function
+relationship: part_of GO:0008150 ! biological_process
+created_by: kchris
+creation_date: 2010-10-21T04:37:54Z
+
+[Term]
+id: GO:0002376
+name: immune system process
+namespace: biological_process
+def: "Any process involved in the development or functioning of the immune system, an organismal system for calibrated responses to potential internal or invasive threats." [GO_REF:0000022, GOC:add, GOC:mtg_15nov05]
+comment: Note that this term is a direct child of 'biological_process ; GO:0008150' because some immune system processes are types of cellular process (GO:0009987), whereas others are types of multicellular organism process (GO:0032501). This term was added by GO_REF:0000022.
+subset: goslim_agr
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_pir
+xref: Wikipedia:Immune_system
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0003013
+name: circulatory system process
+namespace: biological_process
+def: "A organ system process carried out by any of the organs or tissues of the circulatory system. The circulatory system is an organ system that moves extracellular fluids to and from tissue within a multicellular organism." [GOC:mtg_cardio]
+subset: goslim_chembl
+subset: goslim_generic
+xref: Wikipedia:Circulatory_system
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0003674
+name: molecular_function
+namespace: molecular_function
+alt_id: GO:0005554
+def: "The actions of a single gene product or complex at the molecular level consisting of a single biochemical activity or multiple causally linked biochemical activities. A given gene product may exhibit one or more molecular functions." [GOC:go_curators]
+comment: Note that, in addition to forming the root of the molecular function ontology, this term is recommended for use for the annotation of gene products whose molecular function is unknown. When this term is used for annotation, it indicates that no information was available about the molecular function of the gene product annotated as of the date the annotation was made; the evidence code ND, no data, is used to indicate this. Despite its name, this is not a type of 'function' in the sense typically defined by upper ontologies such as Basic Formal Ontology (BFO). It is instead a BFO:process carried out by a single gene product or complex.
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "molecular function" EXACT []
+
+[Term]
+id: GO:0003677
+name: DNA binding
+namespace: molecular_function
+alt_id: GO:0043566
+def: "Any molecular function by which a gene product interacts selectively and non-covalently with DNA (deoxyribonucleic acid)." [GOC:dph, GOC:jl, GOC:tb, GOC:vw]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "microtubule/chromatin interaction" RELATED []
+synonym: "plasmid binding" NARROW []
+synonym: "structure specific DNA binding" RELATED []
+synonym: "structure-specific DNA binding" RELATED []
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0003723
+name: RNA binding
+namespace: molecular_function
+alt_id: GO:0044822
+def: "Interacting selectively and non-covalently with an RNA molecule or a portion thereof." [GOC:jl, GOC:mah]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "poly(A) RNA binding" RELATED []
+synonym: "poly(A)-RNA binding" RELATED []
+synonym: "poly-A RNA binding" RELATED []
+xref: Reactome:REACT_101703 "Exportin-5 recognizes 3' overhang of pre-miRNA, Xenopus tropicalis"
+xref: Reactome:REACT_103323 "Exportin-5 recognizes 3' overhang of pre-miRNA, Dictyostelium discoideum"
+xref: Reactome:REACT_106430 "Exportin-5 recognizes 3' overhang of pre-miRNA, Mus musculus"
+xref: Reactome:REACT_107757 "Exportin-5 recognizes 3' overhang of pre-miRNA, Drosophila melanogaster"
+xref: Reactome:REACT_108232 "Exportin-5 recognizes 3' overhang of pre-miRNA, Oryza sativa"
+xref: Reactome:REACT_108368 "Exportin-5 recognizes 3' overhang of pre-miRNA, Saccharomyces cerevisiae"
+xref: Reactome:REACT_109723 "Exportin-5 recognizes 3' overhang of pre-miRNA, Arabidopsis thaliana"
+xref: Reactome:REACT_12458 "Exportin-5 recognizes 3' overhang of pre-miRNA, Homo sapiens"
+xref: Reactome:REACT_29965 "Exportin-5 recognizes 3' overhang of pre-miRNA, Canis familiaris"
+xref: Reactome:REACT_77167 "Exportin-5 recognizes 3' overhang of pre-miRNA, Gallus gallus"
+xref: Reactome:REACT_78197 "Exportin-5 recognizes 3' overhang of pre-miRNA, Sus scrofa"
+xref: Reactome:REACT_87164 "Exportin-5 recognizes 3' overhang of pre-miRNA, Schizosaccharomyces pombe"
+xref: Reactome:REACT_89329 "Exportin-5 recognizes 3' overhang of pre-miRNA, Rattus norvegicus"
+xref: Reactome:REACT_90531 "Exportin-5 recognizes 3' overhang of pre-miRNA, Danio rerio"
+xref: Reactome:REACT_98683 "Exportin-5 recognizes 3' overhang of pre-miRNA, Taeniopygia guttata"
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0003729
+name: mRNA binding
+namespace: molecular_function
+def: "Interacting selectively and non-covalently with messenger RNA (mRNA), an intermediate molecule between DNA and protein. mRNA includes UTR and coding sequences, but does not contain introns." [GOC:kmv, GOC:pr, SO:0000234]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+is_a: GO:0003723 ! RNA binding
+
+[Term]
+id: GO:0003735
+name: structural constituent of ribosome
+namespace: molecular_function
+alt_id: GO:0003736
+alt_id: GO:0003737
+alt_id: GO:0003738
+alt_id: GO:0003739
+alt_id: GO:0003740
+alt_id: GO:0003741
+alt_id: GO:0003742
+def: "The action of a molecule that contributes to the structural integrity of the ribosome." [GOC:mah]
+comment: Note that this term may be used to annotate ribosomal RNAs as well as ribosomal proteins.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "ribosomal protein" BROAD []
+synonym: "ribosomal RNA" RELATED []
+is_a: GO:0005198 ! structural molecule activity
+
+[Term]
+id: GO:0003924
+name: GTPase activity
+namespace: molecular_function
+def: "Catalysis of the reaction: GTP + H2O = GDP + phosphate." [ISBN:0198547684]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "ARF small monomeric GTPase activity" NARROW []
+synonym: "dynamin GTPase activity" NARROW []
+synonym: "heterotrimeric G-protein GTPase activity" NARROW []
+synonym: "heterotrimeric G-protein GTPase, alpha-subunit" RELATED []
+synonym: "heterotrimeric G-protein GTPase, beta-subunit" RELATED []
+synonym: "heterotrimeric G-protein GTPase, gamma-subunit" RELATED []
+synonym: "hydrolase activity, acting on acid anhydrides, acting on GTP, involved in cellular and subcellular movement" BROAD []
+synonym: "protein-synthesizing GTPase activity" NARROW []
+synonym: "protein-synthesizing GTPase activity, elongation" NARROW []
+synonym: "protein-synthesizing GTPase activity, initiation" NARROW []
+synonym: "protein-synthesizing GTPase activity, termination" NARROW []
+synonym: "Rab small monomeric GTPase activity" NARROW []
+synonym: "Ran small monomeric GTPase activity" NARROW []
+synonym: "Ras small monomeric GTPase activity" NARROW []
+synonym: "RHEB small monomeric GTPase activity" NARROW []
+synonym: "Rho small monomeric GTPase activity" NARROW []
+synonym: "Sar small monomeric GTPase activity" NARROW []
+synonym: "signal-recognition-particle GTPase activity" NARROW []
+synonym: "small monomeric GTPase activity" NARROW []
+synonym: "tubulin GTPase activity" NARROW []
+xref: Reactome:REACT_100432 "trans-Golgi Network Vesicle Scission, Mus musculus"
+xref: Reactome:REACT_100708 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Bos taurus"
+xref: Reactome:REACT_101121 "trans-Golgi Network Vesicle Scission, Rattus norvegicus"
+xref: Reactome:REACT_101520 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Drosophila melanogaster"
+xref: Reactome:REACT_101563 "Loss of Sar1b GTPase, Arabidopsis thaliana"
+xref: Reactome:REACT_101678 "G-protein alpha subunit is inactivated, Gallus gallus"
+xref: Reactome:REACT_102040 "Adenylate cyclase increases the GTPase activity of G alpha-olf, Xenopus tropicalis"
+xref: Reactome:REACT_102208 "Adenylate cyclase increases the GTPase activity of G alpha-olf, Danio rerio"
+xref: Reactome:REACT_102307 "Adenylate cyclase increases the GTPase activity of Gi alpha, Gallus gallus"
+xref: Reactome:REACT_102371 "Vesicle Uncoating, Oryza sativa"
+xref: Reactome:REACT_102510 "trans-Golgi Network Vesicle Scission, Bos taurus"
+xref: Reactome:REACT_102532 "Loss of Sar1b GTPase, Danio rerio"
+xref: Reactome:REACT_103518 "trans-Golgi Network Lysosomal Vesicle Scission, Sus scrofa"
+xref: Reactome:REACT_104081 "G alpha (i) auto-inactivates by hydrolysing GTP to GDP, Mus musculus"
+xref: Reactome:REACT_104477 "G alpha (12/13) auto-inactivates by hydrolysing GTP to GDP, Canis familiaris"
+xref: Reactome:REACT_104739 "Loss of Sar1b GTPase, Dictyostelium discoideum"
+xref: Reactome:REACT_105323 "trans-Golgi Network Vesicle Scission, Canis familiaris"
+xref: Reactome:REACT_105697 "G-protein alpha subunit is inactivated, Saccharomyces cerevisiae"
+xref: Reactome:REACT_105708 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Xenopus tropicalis"
+xref: Reactome:REACT_105854 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Taeniopygia guttata"
+xref: Reactome:REACT_106121 "Vesicle Uncoating, Saccharomyces cerevisiae"
+xref: Reactome:REACT_106217 "Hydrolysis of eEF1A:GTP, Dictyostelium discoideum"
+xref: Reactome:REACT_106301 "Adenylate cyclase increases the GTPase activity of G alpha-olf, Mus musculus"
+xref: Reactome:REACT_106528 "trans-Golgi Network Lysosomal Vesicle Scission, Canis familiaris"
+xref: Reactome:REACT_107176 "G alpha (z) auto-inactivates by hydrolysing GTP to GDP, Taeniopygia guttata"
+xref: Reactome:REACT_107306 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Rattus norvegicus"
+xref: Reactome:REACT_107730 "G alpha (z) auto-inactivates by hydrolysing GTP to GDP, Saccharomyces cerevisiae"
+xref: Reactome:REACT_107820 "Adenylaye cyclase increases the GTPase activity of G alpha-olf, Canis familiaris"
+xref: Reactome:REACT_108363 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Drosophila melanogaster"
+xref: Reactome:REACT_108653 "G-protein alpha subunit is inactivated, Bos taurus"
+xref: Reactome:REACT_108825 "Adenylaye cyclase increases the GTPase activity of G alpha-olf, Drosophila melanogaster"
+xref: Reactome:REACT_108837 "trans-Golgi Network Vesicle Scission, Xenopus tropicalis"
+xref: Reactome:REACT_109360 "G alpha (12/13) auto-inactivates by hydrolysing GTP to GDP, Sus scrofa"
+xref: Reactome:REACT_109897 "Adenylaye cyclase increases the GTPase activity of G alpha-olf, Danio rerio"
+xref: Reactome:REACT_110131 "G alpha (i) auto-inactivates by hydrolysing GTP to GDP, Gallus gallus"
+xref: Reactome:REACT_110443 "G alpha (12/13) auto-inactivates by hydrolysing GTP to GDP, Xenopus tropicalis"
+xref: Reactome:REACT_110557 "trans-Golgi Network Vesicle Scission, Danio rerio"
+xref: Reactome:REACT_110859 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Caenorhabditis elegans"
+xref: Reactome:REACT_110879 "G-protein alpha subunit is inactivated, Canis familiaris"
+xref: Reactome:REACT_110931 "G-protein alpha subunit is inactivated, Sus scrofa"
+xref: Reactome:REACT_111994 "G alpha (z) auto-inactivates by hydrolysing GTP to GDP, Xenopus tropicalis"
+xref: Reactome:REACT_112104 "Endocytosis (internalization) of clathrin-coated vesicle, Sus scrofa"
+xref: Reactome:REACT_112254 "Endocytosis (internalization) of clathrin-coated vesicle, Xenopus tropicalis"
+xref: Reactome:REACT_112389 "Disassembly of COPII coated vesicle, Gallus gallus"
+xref: Reactome:REACT_112587 "trans-Golgi Network Vesicle Scission, Schizosaccharomyces pombe"
+xref: Reactome:REACT_112651 "Vesicle Uncoating, Xenopus tropicalis"
+xref: Reactome:REACT_112671 "Vesicle Uncoating, Plasmodium falciparum"
+xref: Reactome:REACT_113058 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Saccharomyces cerevisiae"
+xref: Reactome:REACT_113209 "G alpha (z) auto-inactivates by hydrolysing GTP to GDP, Schizosaccharomyces pombe"
+xref: Reactome:REACT_113727 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Saccharomyces cerevisiae"
+xref: Reactome:REACT_113832 "Formation of clathrin coated vesicle, Bos taurus"
+xref: Reactome:REACT_113952 "Formation of clathrin coated vesicle, Schizosaccharomyces pombe"
+xref: Reactome:REACT_113954 "Endocytosis (internalization) of clathrin-coated vesicle, Schizosaccharomyces pombe"
+xref: Reactome:REACT_114148 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Schizosaccharomyces pombe"
+xref: Reactome:REACT_114153 "Loss of Sar1b GTPase, Xenopus tropicalis"
+xref: Reactome:REACT_114188 "Formation of clathrin coated vesicle, Sus scrofa"
+xref: Reactome:REACT_114210 "G-protein alpha subunit is inactivated, Schizosaccharomyces pombe"
+xref: Reactome:REACT_114331 "trans-Golgi Network Vesicle Scission, Taeniopygia guttata"
+xref: Reactome:REACT_114379 "Formation of clathrin coated vesicle, Taeniopygia guttata"
+xref: Reactome:REACT_114384 "Hydrolysis of eEF1A:GTP, Gallus gallus"
+xref: Reactome:REACT_114532 "Formation of clathrin coated vesicle, Xenopus tropicalis"
+xref: Reactome:REACT_114620 "Endocytosis (internalization) of clathrin-coated vesicle, Taeniopygia guttata"
+xref: Reactome:REACT_114824 "trans-Golgi Network Lysosomal Vesicle Scission, Taeniopygia guttata"
+xref: Reactome:REACT_115229 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Schizosaccharomyces pombe"
+xref: Reactome:REACT_115324 "Endocytosis (internalization) of clathrin-coated vesicle, Bos taurus"
+xref: Reactome:REACT_12396 "Loss of Sar1b GTPase, Homo sapiens"
+xref: Reactome:REACT_12397 "Endocytosis (internalization) of clathrin-coated vesicle, Homo sapiens"
+xref: Reactome:REACT_12456 "Vesicle Uncoating, Homo sapiens"
+xref: Reactome:REACT_12612 "Endocytosis of clathrin-coated vesicle, Rattus norvegicus"
+xref: Reactome:REACT_15316 "G-protein alpha subunit is inactivated, Homo sapiens"
+xref: Reactome:REACT_15335 "Adenylate cyclase increases the GTPase activity of G alpha-olf, Homo sapiens"
+xref: Reactome:REACT_15449 "Adenylaye cyclase increases the GTPase activity of G alpha-olf, Homo sapiens"
+xref: Reactome:REACT_15495 "Adenylate cyclase increases the GTPase activity of Gi alpha, Homo sapiens"
+xref: Reactome:REACT_19123 "G alpha (12/13) auto-inactivates by hydrolysing GTP to GDP, Homo sapiens"
+xref: Reactome:REACT_19178 "G alpha (z) auto-inactivates by hydrolysing GTP to GDP, Homo sapiens"
+xref: Reactome:REACT_19186 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Homo sapiens"
+xref: Reactome:REACT_19194 "trans-Golgi Network Lysosomal Vesicle Scission, Homo sapiens"
+xref: Reactome:REACT_19219 "G alpha (i) auto-inactivates by hydrolysing GTP to GDP, Homo sapiens"
+xref: Reactome:REACT_19255 "trans-Golgi Network Vesicle Scission, Homo sapiens"
+xref: Reactome:REACT_19317 "G alpha (i)1 auto-inactivates by hydrolysing GTP to GDP, Rattus norvegicus"
+xref: Reactome:REACT_22359 "Formation of clathrin coated vesicle, Homo sapiens"
+xref: Reactome:REACT_28065 "Vesicle Uncoating, Sus scrofa"
+xref: Reactome:REACT_28251 "Hydrolysis of eEF1A:GTP, Danio rerio"
+xref: Reactome:REACT_28269 "Adenylaye cyclase increases the GTPase activity of G alpha-olf, Gallus gallus"
+xref: Reactome:REACT_29162 "trans-Golgi Network Lysosomal Vesicle Scission, Mus musculus"
+xref: Reactome:REACT_30456 "Hydrolysis of eEF1A:GTP, Plasmodium falciparum"
+xref: Reactome:REACT_30463 "Adenylate cyclase increases the GTPase activity of G alpha-olf, Bos taurus"
+xref: Reactome:REACT_30562 "Endocytosis (internalization) of clathrin-coated vesicle, Caenorhabditis elegans"
+xref: Reactome:REACT_30687 "G-protein alpha subunit is inactivated, Xenopus tropicalis"
+xref: Reactome:REACT_30707 "trans-Golgi Network Vesicle Scission, Caenorhabditis elegans"
+xref: Reactome:REACT_30942 "Vesicle Uncoating, Rattus norvegicus"
+xref: Reactome:REACT_31226 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Mus musculus"
+xref: Reactome:REACT_31474 "Formation of clathrin coated vesicle, Danio rerio"
+xref: Reactome:REACT_31530 "Adenylaye cyclase increases the GTPase activity of G alpha-olf, Caenorhabditis elegans"
+xref: Reactome:REACT_31599 "trans-Golgi Network Lysosomal Vesicle Scission, Danio rerio"
+xref: Reactome:REACT_31709 "Hydrolysis of eEF1A:GTP, Drosophila melanogaster"
+xref: Reactome:REACT_31727 "Adenylate cyclase increases the GTPase activity of G alpha-olf, Taeniopygia guttata"
+xref: Reactome:REACT_31850 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Gallus gallus"
+xref: Reactome:REACT_32006 "Loss of Sar1b GTPase, Canis familiaris"
+xref: Reactome:REACT_32028 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Danio rerio"
+xref: Reactome:REACT_32914 "Vesicle Uncoating, Dictyostelium discoideum"
+xref: Reactome:REACT_33948 "trans-Golgi Network Lysosomal Vesicle Scission, Rattus norvegicus"
+xref: Reactome:REACT_34113 "Vesicle Uncoating, Schizosaccharomyces pombe"
+xref: Reactome:REACT_34480 "G-protein alpha subunit is inactivated, Caenorhabditis elegans"
+xref: Reactome:REACT_34592 "G alpha (i) auto-inactivates by hydrolysing GTP to GDP, Xenopus tropicalis"
+xref: Reactome:REACT_34735 "Adenylate cyclase increases the GTPase activity of Gi alpha, Taeniopygia guttata"
+xref: Reactome:REACT_348 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Homo sapiens"
+xref: Reactome:REACT_36834 "trans-Golgi Network Lysosomal Vesicle Scission, Bos taurus"
+xref: Reactome:REACT_37542 "G alpha (i) auto-inactivates by hydrolysing GTP to GDP, Sus scrofa"
+xref: Reactome:REACT_552 "Hydrolysis of eEF1A:GTP, Homo sapiens"
+xref: Reactome:REACT_6171 "Hydrolysis of Ran:GTP to Ran:GDP, Homo sapiens"
+xref: Reactome:REACT_712 "Hydrolysis of reEF1A:GTP, Oryctolagus cuniculus"
+xref: Reactome:REACT_75799 "Disassembly of COPII coated vesicle, Homo sapiens"
+xref: Reactome:REACT_77032 "Hydrolysis of eEF1A:GTP, Canis familiaris"
+xref: Reactome:REACT_77303 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Danio rerio"
+xref: Reactome:REACT_78069 "G alpha (12/13) auto-inactivates by hydrolysing GTP to GDP, Caenorhabditis elegans"
+xref: Reactome:REACT_78231 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Taeniopygia guttata"
+xref: Reactome:REACT_78653 "Adenylaye cyclase increases the GTPase activity of G alpha-olf, Bos taurus"
+xref: Reactome:REACT_78945 "G-protein alpha subunit is inactivated, Rattus norvegicus"
+xref: Reactome:REACT_79558 "G alpha (i) auto-inactivates by hydrolysing GTP to GDP, Taeniopygia guttata"
+xref: Reactome:REACT_79620 "Adenylaye cyclase increases the GTPase activity of G alpha-olf, Mus musculus"
+xref: Reactome:REACT_80275 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Bos taurus"
+xref: Reactome:REACT_80612 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Canis familiaris"
+xref: Reactome:REACT_81304 "Loss of Sar1b GTPase, Taeniopygia guttata"
+xref: Reactome:REACT_81448 "Endocytosis (internalization) of clathrin-coated vesicle, Canis familiaris"
+xref: Reactome:REACT_81580 "Disassembly of COPII coated vesicle, Mus musculus"
+xref: Reactome:REACT_81664 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Caenorhabditis elegans"
+xref: Reactome:REACT_81879 "Vesicle Uncoating, Drosophila melanogaster"
+xref: Reactome:REACT_82203 "Formation of clathrin coated vesicle, Canis familiaris"
+xref: Reactome:REACT_82263 "G-protein alpha subunit is inactivated, Taeniopygia guttata"
+xref: Reactome:REACT_82457 "G alpha (12/13) auto-inactivates by hydrolysing GTP to GDP, Taeniopygia guttata"
+xref: Reactome:REACT_82603 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Canis familiaris"
+xref: Reactome:REACT_82704 "Loss of Sar1b GTPase, Rattus norvegicus"
+xref: Reactome:REACT_83308 "Adenylate cyclase increases the GTPase activity of G alpha-olf, Rattus norvegicus"
+xref: Reactome:REACT_83403 "G-protein alpha subunit is inactivated, Drosophila melanogaster"
+xref: Reactome:REACT_83440 "Hydrolysis of eEF1A:GTP, Schizosaccharomyces pombe"
+xref: Reactome:REACT_83730 "Loss of Sar1b GTPase, Plasmodium falciparum"
+xref: Reactome:REACT_84204 "Endocytosis (internalization) of clathrin-coated vesicle, Danio rerio"
+xref: Reactome:REACT_84553 "Vesicle Uncoating, Canis familiaris"
+xref: Reactome:REACT_84696 "G-protein alpha subunit is inactivated, Danio rerio"
+xref: Reactome:REACT_84712 "Hydrolysis of eEF1A:GTP, Saccharomyces cerevisiae"
+xref: Reactome:REACT_84735 "G alpha (12/13) auto-inactivates by hydrolysing GTP to GDP, Rattus norvegicus"
+xref: Reactome:REACT_85008 "Vesicle Uncoating, Danio rerio"
+xref: Reactome:REACT_85418 "Loss of Sar1b GTPase, Gallus gallus"
+xref: Reactome:REACT_85769 "Disassembly of COPII coated vesicle, Danio rerio"
+xref: Reactome:REACT_85972 "Adenylate cyclase increases the GTPase activity of G alpha-olf, Canis familiaris"
+xref: Reactome:REACT_86227 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Dictyostelium discoideum"
+xref: Reactome:REACT_86358 "trans-Golgi Network Lysosomal Vesicle Scission, Caenorhabditis elegans"
+xref: Reactome:REACT_86400 "G alpha (12/13) auto-inactivates by hydrolysing GTP to GDP, Dictyostelium discoideum"
+xref: Reactome:REACT_86630 "Vesicle Uncoating, Mus musculus"
+xref: Reactome:REACT_86760 "Adenylate cyclase increases the GTPase activity of G alpha-olf, Gallus gallus"
+xref: Reactome:REACT_86972 "Loss of Sar1b GTPase, Mus musculus"
+xref: Reactome:REACT_87409 "G alpha (z) auto-inactivates by hydrolysing GTP to GDP, Dictyostelium discoideum"
+xref: Reactome:REACT_87506 "Formation of clathrin coated vesicle, Rattus norvegicus"
+xref: Reactome:REACT_87558 "G alpha (z) auto-inactivates by hydrolysing GTP to GDP, Mus musculus"
+xref: Reactome:REACT_87653 "Endocytosis (internalization) of clathrin-coated vesicle, Mus musculus"
+xref: Reactome:REACT_87661 "Formation of clathrin coated vesicle, Drosophila melanogaster"
+xref: Reactome:REACT_88045 "Vesicle Uncoating, Gallus gallus"
+xref: Reactome:REACT_88357 "G alpha (z) auto-inactivates by hydrolysing GTP to GDP, Canis familiaris"
+xref: Reactome:REACT_89231 "Loss of Sar1b GTPase, Bos taurus"
+xref: Reactome:REACT_89292 "G alpha (12/13) auto-inactivates by hydrolysing GTP to GDP, Gallus gallus"
+xref: Reactome:REACT_89416 "G alpha (i) auto-inactivates by hydrolysing GTP to GDP, Bos taurus"
+xref: Reactome:REACT_89668 "trans-Golgi Network Lysosomal Vesicle Scission, Xenopus tropicalis"
+xref: Reactome:REACT_89763 "Vesicle Uncoating, Taeniopygia guttata"
+xref: Reactome:REACT_90050 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Mus musculus"
+xref: Reactome:REACT_90064 "Hydrolysis of eEF1A:GTP, Mus musculus"
+xref: Reactome:REACT_90517 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Xenopus tropicalis"
+xref: Reactome:REACT_90703 "G-protein alpha subunit is inactivated, Dictyostelium discoideum"
+xref: Reactome:REACT_91199 "Adenylate cyclase increases the GTPase activity of Gi alpha, Bos taurus"
+xref: Reactome:REACT_91588 "trans-Golgi Network Vesicle Scission, Drosophila melanogaster"
+xref: Reactome:REACT_92176 "Endocytosis (internalization) of clathrin-coated vesicle, Drosophila melanogaster"
+xref: Reactome:REACT_92197 "G alpha (12/13) auto-inactivates by hydrolysing GTP to GDP, Bos taurus"
+xref: Reactome:REACT_92198 "Loss of Sar1b GTPase, Oryza sativa"
+xref: Reactome:REACT_92450 "G alpha (12/13) auto-inactivates by hydrolysing GTP to GDP, Danio rerio"
+xref: Reactome:REACT_93249 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Dictyostelium discoideum"
+xref: Reactome:REACT_93305 "Loss of Sar1b GTPase, Sus scrofa"
+xref: Reactome:REACT_93641 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Gallus gallus"
+xref: Reactome:REACT_93742 "G-protein alpha subunit is inactivated, Mus musculus"
+xref: Reactome:REACT_93772 "G alpha (z) auto-inactivates by hydrolysing GTP to GDP, Gallus gallus"
+xref: Reactome:REACT_94019 "G alpha (s) auto-inactivates by hydrolysing GTP to GDP, Sus scrofa"
+xref: Reactome:REACT_94095 "trans-Golgi Network Vesicle Scission, Sus scrofa"
+xref: Reactome:REACT_94305 "Adenylate cyclase increases the GTPase activity of Gi alpha, Xenopus tropicalis"
+xref: Reactome:REACT_94760 "Adenylate cyclase increases the GTPase activity of Gi alpha, Danio rerio"
+xref: Reactome:REACT_95238 "Adenylaye cyclase increases the GTPase activity of G alpha-olf, Rattus norvegicus"
+xref: Reactome:REACT_95563 "Adenylate cyclase increases the GTPase activity of Gi alpha, Canis familiaris"
+xref: Reactome:REACT_96019 "Loss of Sar1b GTPase, Drosophila melanogaster"
+xref: Reactome:REACT_96132 "G alpha (12/13) auto-inactivates by hydrolysing GTP to GDP, Drosophila melanogaster"
+xref: Reactome:REACT_96223 "G alpha (z) auto-inactivates by hydrolysing GTP to GDP, Sus scrofa"
+xref: Reactome:REACT_96612 "Adenylate cyclase increases the GTPase activity of Gi alpha, Rattus norvegicus"
+xref: Reactome:REACT_96881 "Adenylaye cyclase increases the GTPase activity of G alpha-olf, Xenopus tropicalis"
+xref: Reactome:REACT_97284 "Loss of Sar1b GTPase, Saccharomyces cerevisiae"
+xref: Reactome:REACT_97405 "Adenylaye cyclase increases the GTPase activity of G alpha-olf, Taeniopygia guttata"
+xref: Reactome:REACT_97595 "G alpha (i) auto-inactivates by hydrolysing GTP to GDP, Danio rerio"
+xref: Reactome:REACT_97794 "Loss of Sar1b GTPase, Schizosaccharomyces pombe"
+xref: Reactome:REACT_98431 "Formation of clathrin coated vesicle, Caenorhabditis elegans"
+xref: Reactome:REACT_98556 "Vesicle Uncoating, Bos taurus"
+xref: Reactome:REACT_98837 "G alpha (i) auto-inactivates by hydrolysing GTP to GDP, Canis familiaris"
+xref: Reactome:REACT_98859 "Adenylate cyclase increases the GTPase activity of Gi alpha, Mus musculus"
+xref: Reactome:REACT_99479 "G alpha (12/13) auto-inactivates by hydrolysing GTP to GDP, Mus musculus"
+xref: Reactome:REACT_99533 "G alpha (q) auto-inactivates by hydrolysing GTP to GDP, Sus scrofa"
+xref: Reactome:REACT_99616 "Formation of clathrin coated vesicle, Mus musculus"
+xref: RHEA:19672
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0004386
+name: helicase activity
+namespace: molecular_function
+def: "Catalysis of the reaction: NTP + H2O = NDP + phosphate, to drive the unwinding of a DNA or RNA helix." [GOC:mah, ISBN:0198506732]
+comment: Note that most helicases catalyze processive duplex unwinding.
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_yeast
+subset: gosubset_prok
+xref: Reactome:REACT_101111 "Addition of the third nucleotide on the nascent transcript, Saccharomyces cerevisiae"
+xref: Reactome:REACT_101247 "Formation of open bubble structure in DNA by helicases, Bos taurus"
+xref: Reactome:REACT_101622 "MCM8 mediated fork unwinding, Danio rerio"
+xref: Reactome:REACT_101644 "Formation of open bubble structure in DNA by helicases, Oryza sativa"
+xref: Reactome:REACT_101823 "MCM2-7 mediated fork unwinding, Plasmodium falciparum"
+xref: Reactome:REACT_101994 "Addition of the fourth nucleotide on the Nascent Transcript: Second Transition, Xenopus tropicalis"
+xref: Reactome:REACT_102121 "Addition of the third nucleotide on the nascent transcript, Rattus norvegicus"
+xref: Reactome:REACT_102441 "Addition of the fourth nucleotide on the Nascent Transcript: Second Transition, Gallus gallus"
+xref: Reactome:REACT_102560 "MCM2-7 mediated fork unwinding, Oryza sativa"
+xref: Reactome:REACT_1033 "Formation of open bubble structure in DNA by helicases, Homo sapiens"
+xref: Reactome:REACT_103861 "MCM8 mediated fork unwinding, Bos taurus"
+xref: Reactome:REACT_103881 "RNA Polymerase II Promoter Opening: First Transition, Dictyostelium discoideum"
+xref: Reactome:REACT_103897 "MCM8 mediated fork unwinding, Mus musculus"
+xref: Reactome:REACT_103959 "Addition of the fourth nucleotide on the Nascent Transcript: Second Transition, Rattus norvegicus"
+xref: Reactome:REACT_104221 "MCM2-7 mediated fork unwinding, Rattus norvegicus"
+xref: Reactome:REACT_105950 "MCM2-7 mediated fork unwinding, Xenopus tropicalis"
+xref: Reactome:REACT_106346 "Formation of open bubble structure in DNA by helicases, Taeniopygia guttata"
+xref: Reactome:REACT_107072 "Formation of open bubble structure in DNA by helicases, Mus musculus"
+xref: Reactome:REACT_107495 "RNA Polymerase II Promoter Opening: First Transition, Taeniopygia guttata"
+xref: Reactome:REACT_108159 "Addition of the fourth nucleotide on the Nascent Transcript: Second Transition, Dictyostelium discoideum"
+xref: Reactome:REACT_108648 "Addition of the third nucleotide on the nascent transcript, Arabidopsis thaliana"
+xref: Reactome:REACT_108654 "MCM2-7 mediated fork unwinding, Schizosaccharomyces pombe"
+xref: Reactome:REACT_109035 "RNA Polymerase II Promoter Opening: First Transition, Schizosaccharomyces pombe"
+xref: Reactome:REACT_109161 "Addition of the fourth nucleotide on the Nascent Transcript: Second Transition, Arabidopsis thaliana"
+xref: Reactome:REACT_110588 "MCM8 mediated fork unwinding, Xenopus tropicalis"
+xref: Reactome:REACT_110827 "Formation of open bubble structure in DNA by helicases, Danio rerio"
+xref: Reactome:REACT_110845 "Cap-bound mRNA is activated by helicases, Mus musculus"
+xref: Reactome:REACT_112208 "MCM8 mediated fork unwinding, Drosophila melanogaster"
+xref: Reactome:REACT_112817 "Cap-bound mRNA is activated by helicases, Schizosaccharomyces pombe"
+xref: Reactome:REACT_113177 "Formation of open bubble structure in DNA by helicases, Caenorhabditis elegans"
+xref: Reactome:REACT_1521 "Cap-bound mRNA is activated by helicases, Homo sapiens"
+xref: Reactome:REACT_1817 "Addition of the fourth nucleotide on the Nascent Transcript: Second Transition, Homo sapiens"
+xref: Reactome:REACT_1844 "RNA Polymerase II Promoter Opening: First Transition, Homo sapiens"
+xref: Reactome:REACT_28131 "Addition of the fourth nucleotide on the Nascent Transcript: Second Transition, Drosophila melanogaster"
+xref: Reactome:REACT_28343 "MCM2-7 mediated fork unwinding, Danio rerio"
+xref: Reactome:REACT_28810 "Addition of the third nucleotide on the nascent transcript, Oryza sativa"
+xref: Reactome:REACT_28880 "MCM2-7 mediated fork unwinding, Drosophila melanogaster"
+xref: Reactome:REACT_29155 "Addition of the third nucleotide on the nascent transcript, Drosophila melanogaster"
+xref: Reactome:REACT_29217 "Formation of open bubble structure in DNA by helicases, Xenopus tropicalis"
+xref: Reactome:REACT_29818 "Addition of the fourth nucleotide on the Nascent Transcript: Second Transition, Oryza sativa"
+xref: Reactome:REACT_29850 "RNA Polymerase II Promoter Opening: First Transition, Saccharomyces cerevisiae"
+xref: Reactome:REACT_30013 "MCM8 mediated fork unwinding, Rattus norvegicus"
+xref: Reactome:REACT_30989 "MCM8 mediated fork unwinding, Arabidopsis thaliana"
+xref: Reactome:REACT_31034 "Cap-bound mRNA is activated by helicases, Danio rerio"
+xref: Reactome:REACT_31090 "MCM2-7 mediated fork unwinding, Gallus gallus"
+xref: Reactome:REACT_31554 "Addition of the fourth nucleotide on the Nascent Transcript: Second Transition, Schizosaccharomyces pombe"
+xref: Reactome:REACT_32533 "Addition of the fourth nucleotide on the Nascent Transcript: Second Transition, Caenorhabditis elegans"
+xref: Reactome:REACT_33205 "MCM8 mediated fork unwinding, Canis familiaris"
+xref: Reactome:REACT_34016 "Formation of open bubble structure in DNA by helicases, Rattus norvegicus"
+xref: Reactome:REACT_34089 "MCM2-7 mediated fork unwinding, Dictyostelium discoideum"
+xref: Reactome:REACT_34560 "MCM8 mediated fork unwinding, Sus scrofa"
+xref: Reactome:REACT_40 "Addition of the third nucleotide on the nascent transcript, Homo sapiens"
+xref: Reactome:REACT_6134 "HIV-1 Promoter Opening: First Transition, Homo sapiens"
+xref: Reactome:REACT_6184 "Addition of the fourth nucleotide on the nascent HIV-1 transcript: Second Transition, Homo sapiens"
+xref: Reactome:REACT_6325 "Addition of the third nucleotide on the nascent HIV-1 transcript, Homo sapiens"
+xref: Reactome:REACT_6758 "Xenopus Mcm8 mediated fork unwinding, Xenopus laevis"
+xref: Reactome:REACT_6768 "MCM8 mediated fork unwinding, Homo sapiens"
+xref: Reactome:REACT_6853 "Yeast Mcm2-7 mediated fork unwinding, Saccharomyces cerevisiae"
+xref: Reactome:REACT_6922 "MCM2-7 mediated fork unwinding, Homo sapiens"
+xref: Reactome:REACT_78086 "RNA Polymerase II Promoter Opening: First Transition, Rattus norvegicus"
+xref: Reactome:REACT_78462 "Formation of open bubble structure in DNA by helicases, Drosophila melanogaster"
+xref: Reactome:REACT_78667 "MCM2-7 mediated fork unwinding, Canis familiaris"
+xref: Reactome:REACT_78771 "MCM8 mediated fork unwinding, Dictyostelium discoideum"
+xref: Reactome:REACT_79759 "Addition of the fourth nucleotide on the Nascent Transcript: Second Transition, Mus musculus"
+xref: Reactome:REACT_80107 "RNA Polymerase II Promoter Opening: First Transition, Arabidopsis thaliana"
+xref: Reactome:REACT_80325 "Addition of the fourth nucleotide on the Nascent Transcript: Second Transition, Danio rerio"
+xref: Reactome:REACT_80500 "MCM8 mediated fork unwinding, Gallus gallus"
+xref: Reactome:REACT_80532 "Addition of the third nucleotide on the nascent transcript, Gallus gallus"
+xref: Reactome:REACT_80605 "Addition of the third nucleotide on the nascent transcript, Mus musculus"
+xref: Reactome:REACT_81126 "Addition of the third nucleotide on the nascent transcript, Schizosaccharomyces pombe"
+xref: Reactome:REACT_81335 "RNA Polymerase II Promoter Opening: First Transition, Gallus gallus"
+xref: Reactome:REACT_81427 "MCM8 mediated fork unwinding, Taeniopygia guttata"
+xref: Reactome:REACT_81441 "MCM8 mediated fork unwinding, Oryza sativa"
+xref: Reactome:REACT_81682 "Formation of open bubble structure in DNA by helicases, Canis familiaris"
+xref: Reactome:REACT_82776 "RNA Polymerase II Promoter Opening: First Transition, Danio rerio"
+xref: Reactome:REACT_83794 "Formation of open bubble structure in DNA by helicases, Gallus gallus"
+xref: Reactome:REACT_84565 "Formation of open bubble structure in DNA by helicases, Schizosaccharomyces pombe"
+xref: Reactome:REACT_84574 "Cap-bound mRNA is activated by helicases, Canis familiaris"
+xref: Reactome:REACT_84809 "MCM2-7 mediated fork unwinding, Mus musculus"
+xref: Reactome:REACT_84907 "MCM2-7 mediated fork unwinding, Taeniopygia guttata"
+xref: Reactome:REACT_85111 "Cap-bound mRNA is activated by helicases, Drosophila melanogaster"
+xref: Reactome:REACT_85172 "MCM2-7 mediated fork unwinding, Arabidopsis thaliana"
+xref: Reactome:REACT_86220 "MCM2-7 mediated fork unwinding, Caenorhabditis elegans"
+xref: Reactome:REACT_88362 "Addition of the third nucleotide on the nascent transcript, Caenorhabditis elegans"
+xref: Reactome:REACT_89000 "MCM2-7 mediated fork unwinding, Bos taurus"
+xref: Reactome:REACT_89030 "Formation of open bubble structure in DNA by helicases, Saccharomyces cerevisiae"
+xref: Reactome:REACT_89363 "Addition of the third nucleotide on the nascent transcript, Xenopus tropicalis"
+xref: Reactome:REACT_89694 "RNA Polymerase II Promoter Opening: First Transition, Drosophila melanogaster"
+xref: Reactome:REACT_91822 "MCM8 mediated fork unwinding, Plasmodium falciparum"
+xref: Reactome:REACT_93391 "RNA Polymerase II Promoter Opening: First Transition, Oryza sativa"
+xref: Reactome:REACT_93711 "RNA Polymerase II Promoter Opening: First Transition, Mus musculus"
+xref: Reactome:REACT_94645 "RNA Polymerase II Promoter Opening: First Transition, Xenopus tropicalis"
+xref: Reactome:REACT_94679 "RNA Polymerase II Promoter Opening: First Transition, Caenorhabditis elegans"
+xref: Reactome:REACT_95942 "Addition of the fourth nucleotide on the Nascent Transcript: Second Transition, Saccharomyces cerevisiae"
+xref: Reactome:REACT_95993 "Formation of open bubble structure in DNA by helicases, Arabidopsis thaliana"
+xref: Reactome:REACT_98273 "Addition of the third nucleotide on the nascent transcript, Dictyostelium discoideum"
+xref: Reactome:REACT_98302 "Formation of open bubble structure in DNA by helicases, Sus scrofa"
+xref: Reactome:REACT_98745 "Cap-bound mRNA is activated by helicases, Xenopus tropicalis"
+xref: Reactome:REACT_99120 "Addition of the third nucleotide on the nascent transcript, Danio rerio"
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0004518
+name: nuclease activity
+namespace: molecular_function
+def: "Catalysis of the hydrolysis of ester linkages within nucleic acids." [ISBN:0198547684]
+comment: Note that 'tRNA nucleotidyltransferase activity ; GO:0009022', also known as 'ribonuclease PH', and 'DNA-(apurinic or apyrimidinic site) lyase activity ; GO:0003906' do not have parentage in the 'nuclease activity' branch of the ontology because both GO and the Enzyme Commission define nuclease activity as a type of hydrolysis.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+xref: EC:3.1
+is_a: GO:0003674 ! molecular_function
+relationship: part_of GO:0034641 ! cellular nitrogen compound metabolic process
+
+[Term]
+id: GO:0004871
+name: signal transducer activity
+namespace: molecular_function
+alt_id: GO:0005062
+alt_id: GO:0009369
+alt_id: GO:0009370
+def: "Conveys a signal across a cell to trigger a change in cell function or state. A signal is a physical entity or change in state that is used to transfer information in order to trigger a response." [GOC:go_curators]
+comment: Ligands do NOT have the molecular function 'signal transducer activity'.
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "hematopoietin/interferon-class (D200-domain) cytokine receptor signal transducer activity" NARROW []
+synonym: "quorum sensing response regulator activity" NARROW []
+synonym: "quorum sensing signal generator activity" NARROW []
+is_a: GO:0003674 ! molecular_function
+intersection_of: GO:0003674 ! molecular_function
+intersection_of: part_of GO:0007165 ! signal transduction
+relationship: part_of GO:0007165 ! signal transduction
+
+[Term]
+id: GO:0005198
+name: structural molecule activity
+namespace: molecular_function
+def: "The action of a molecule that contributes to the structural integrity of a complex or its assembly within or outside a cell." [GOC:mah, GOC:vw]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0005575
+name: cellular_component
+namespace: cellular_component
+alt_id: GO:0008372
+def: "The part of a cell, extracellular environment or virus in which a gene product is located. A gene product may be located in one or more parts of a cell and its location may be as specific as a particular macromolecular complex, that is, a stable, persistent association of macromolecules that function together." [GOC:go_curators, NIF_Subcellular:sao-1337158144]
+comment: Note that, in addition to forming the root of the cellular component ontology, this term is recommended for use for the annotation of gene products whose cellular component is unknown. Note that when this term is used for annotation, it indicates that no information was available about the cellular component of the gene product annotated as of the date the annotation was made; the evidence code ND, no data, is used to indicate this.
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "cell or subcellular entity" EXACT []
+synonym: "cellular component" EXACT []
+synonym: "subcellular entity" RELATED [NIF_Subcellular:nlx_subcell_100315]
+xref: NIF_Subcellular:sao-1337158144
+xref: NIF_Subcellular:sao1337158144
+
+[Term]
+id: GO:0005576
+name: extracellular region
+namespace: cellular_component
+def: "The space external to the outermost structure of a cell. For cells without external protective or external encapsulating structures this refers to space outside of the plasma membrane. This term covers the host cell environment outside an intracellular parasite." [GOC:go_curators]
+comment: Note that this term is intended to annotate gene products that are not attached to the cell surface. For gene products from multicellular organisms which are secreted from a cell but retained within the organism (i.e. released into the interstitial fluid or blood), consider the cellular component term 'extracellular space ; GO:0005615'.
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_mouse
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "extracellular" EXACT []
+xref: Wikipedia:Extracellular
+is_a: GO:0005575 ! cellular_component
+
+[Term]
+id: GO:0005578
+name: proteinaceous extracellular matrix
+namespace: cellular_component
+def: "A layer consisting mainly of proteins (especially collagen) and glycosaminoglycans (mostly as proteoglycans) that forms a sheet underlying or overlying cells such as endothelial and epithelial cells. The proteins are secreted by cells in the vicinity. An example of this component is found in Mus musculus." [GOC:mtg_sensu, ISBN:0198547684]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_plant
+is_a: GO:0005575 ! cellular_component
+relationship: part_of GO:0005576 ! extracellular region
+
+[Term]
+id: GO:0005615
+name: extracellular space
+namespace: cellular_component
+def: "That part of a multicellular organism outside the cells proper, usually taken to be outside the plasma membranes, and occupied by fluid." [ISBN:0198547684]
+comment: Note that for multicellular organisms, the extracellular space refers to everything outside a cell, but still within the organism (excluding the extracellular matrix). Gene products from a multi-cellular organism that are secreted from a cell into the interstitial fluid or blood can therefore be annotated to this term.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_plant
+synonym: "intercellular space" RELATED []
+xref: NIF_Subcellular:sao1425028079
+is_a: GO:0005575 ! cellular_component
+relationship: part_of GO:0005576 ! extracellular region
+
+[Term]
+id: GO:0005618
+name: cell wall
+namespace: cellular_component
+def: "The rigid or semi-rigid envelope lying outside the cell membrane of plant, fungal, most prokaryotic cells and some protozoan parasites, maintaining their shape and protecting them from osmotic lysis. In plants it is made of cellulose and, often, lignin; in fungi it is composed largely of polysaccharides; in bacteria it is composed of peptidoglycan; in protozoan parasites such as Giardia species, it's made of carbohydrates and proteins." [GOC:giardia, http://en.wikipedia.org/wiki/Microbial_cyst, ISBN:0198547684, PMID:15134259]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+xref: Wikipedia:Cell_wall
+is_a: GO:0030312 ! external encapsulating structure
+
+[Term]
+id: GO:0005622
+name: intracellular
+namespace: cellular_component
+def: "The living contents of a cell; the matter contained within (but not including) the plasma membrane, usually taken to exclude large vacuoles and masses of secretory or ingested material. In eukaryotes it includes the nucleus and cytoplasm." [ISBN:0198506732]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "internal to cell" EXACT []
+synonym: "nucleocytoplasm" RELATED [GOC:mah]
+synonym: "protoplasm" EXACT []
+synonym: "protoplast" RELATED [GOC:mah]
+xref: Wikipedia:Intracellular
+is_a: GO:0005575 ! cellular_component
+relationship: part_of GO:0005623 ! cell
+
+[Term]
+id: GO:0005623
+name: cell
+namespace: cellular_component
+def: "The basic structural and functional unit of all organisms. Includes the plasma membrane and any external encapsulating structures such as the cell wall and cell envelope." [GOC:go_curators]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_plant
+subset: gosubset_prok
+xref: NIF_Subcellular:sao1813327414
+xref: Wikipedia:Cell_(biology)
+is_a: GO:0005575 ! cellular_component
+property_value: IAO:0000589 "cell and encapsulating structures" xsd:string
+
+[Term]
+id: GO:0005634
+name: nucleus
+namespace: cellular_component
+def: "A membrane-bounded organelle of eukaryotic cells in which chromosomes are housed and replicated. In most cells, the nucleus contains all of the cell's chromosomes except the organellar chromosomes, and is the site of RNA synthesis and processing. In some species, or in specialized cell types, RNA metabolism or DNA replication may be absent." [GOC:go_curators]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_mouse
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+synonym: "cell nucleus" EXACT []
+xref: NIF_Subcellular:sao1702920020
+xref: Wikipedia:Cell_nucleus
+is_a: GO:0043226 ! organelle
+relationship: part_of GO:0005622 ! intracellular
+
+[Term]
+id: GO:0005635
+name: nuclear envelope
+namespace: cellular_component
+alt_id: GO:0005636
+def: "The double lipid bilayer enclosing the nucleus and separating its contents from the rest of the cytoplasm; includes the intermembrane space, a gap of width 20-40 nm (also called the perinuclear space)." [ISBN:0198547684]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_plant
+xref: Wikipedia:Nuclear_envelope
+is_a: GO:0005575 ! cellular_component
+relationship: part_of GO:0005634 ! nucleus
+
+[Term]
+id: GO:0005654
+name: nucleoplasm
+namespace: cellular_component
+def: "That part of the nuclear content other than the chromosomes or the nucleolus." [GOC:ma, ISBN:0124325653]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_plant
+xref: NIF_Subcellular:sao661522542
+xref: Wikipedia:Nucleoplasm
+is_a: GO:0005575 ! cellular_component
+relationship: part_of GO:0005634 ! nucleus
+
+[Term]
+id: GO:0005694
+name: chromosome
+namespace: cellular_component
+def: "A structure composed of a very long molecule of DNA and associated proteins (e.g. histones) that carries hereditary information." [ISBN:0198547684]
+comment: Chromosomes include parts that are not part of the chromatin.  Examples include the kinetochore.
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "chromatid" RELATED []
+synonym: "interphase chromosome" NARROW []
+synonym: "prophase chromosome" NARROW []
+xref: Wikipedia:Chromosome
+is_a: GO:0043226 ! organelle
+relationship: part_of GO:0005622 ! intracellular
+
+[Term]
+id: GO:0005730
+name: nucleolus
+namespace: cellular_component
+def: "A small, dense body one or more of which are present in the nucleus of eukaryotic cells. It is rich in RNA and protein, is not bounded by a limiting membrane, and is not seen during mitosis. Its prime function is the transcription of the nucleolar DNA into 45S ribosomal-precursor RNA, the processing of this RNA into 5.8S, 18S, and 28S components of ribosomal RNA, and the association of these components with 5S RNA and proteins synthesized outside the nucleolus. This association results in the formation of ribonucleoprotein precursors; these pass into the cytoplasm and mature into the 40S and 60S subunits of the ribosome." [ISBN:0198506732]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+xref: NIF_Subcellular:sao1820400233
+xref: Wikipedia:Nucleolus
+is_a: GO:0043226 ! organelle
+relationship: part_of GO:0005634 ! nucleus
+
+[Term]
+id: GO:0005737
+name: cytoplasm
+namespace: cellular_component
+def: "All of the contents of a cell excluding the plasma membrane and nucleus, but including other subcellular structures." [ISBN:0198547684]
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+xref: Wikipedia:Cytoplasm
+is_a: GO:0005575 ! cellular_component
+relationship: part_of GO:0005622 ! intracellular
+
+[Term]
+id: GO:0005739
+name: mitochondrion
+namespace: cellular_component
+def: "A semiautonomous, self replicating organelle that occurs in varying numbers, shapes, and sizes in the cytoplasm of virtually all eukaryotic cells. It is notably the site of tissue respiration." [GOC:giardia, ISBN:0198506732]
+comment: Some anaerobic or microaerophilic organisms (e.g. Entamoeba histolytica, Giardia intestinalis and several Microsporidia species) do not have mitochondria, and contain mitochondrion-related organelles (MROs) instead, called mitosomes or hydrogenosomes, very likely derived from mitochondria. To annotate gene products located in these mitochondrial relics in species such as Entamoeba histolytica, Giardia intestinalis or others, please use GO:0032047 'mitosome' or GO:0042566 'hydrogenosome'. (See PMID:24316280 for a list of species currently known to contain mitochondrion-related organelles.)
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+synonym: "mitochondria" EXACT []
+xref: NIF_Subcellular:sao1860313010
+xref: Wikipedia:Mitochondrion
+is_a: GO:0043226 ! organelle
+relationship: part_of GO:0005737 ! cytoplasm
+
+[Term]
+id: GO:0005764
+name: lysosome
+namespace: cellular_component
+def: "A small lytic vacuole that has cell cycle-independent morphology and is found in most animal cells and that contains a variety of hydrolases, most of which have their maximal activities in the pH range 5-6. The contained enzymes display latency if properly isolated. About 40 different lysosomal hydrolases are known and lysosomes have a great variety of morphologies and functions." [GOC:mah, ISBN:0198506732]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_plant
+xref: NIF_Subcellular:sao585356902
+xref: Wikipedia:Lysosome
+is_a: GO:0005773 ! vacuole
+
+[Term]
+id: GO:0005768
+name: endosome
+namespace: cellular_component
+def: "A vacuole to which materials ingested by endocytosis are delivered." [ISBN:0198506732, PMID:19696797]
+subset: goslim_agr
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_pir
+subset: goslim_plant
+xref: NIF_Subcellular:sao1720343330
+xref: Wikipedia:Endosome
+is_a: GO:0031410 ! cytoplasmic vesicle
+
+[Term]
+id: GO:0005773
+name: vacuole
+namespace: cellular_component
+def: "A closed structure, found only in eukaryotic cells, that is completely surrounded by unit membrane and contains liquid material. Cells contain one or several vacuoles, that may have different functions from each other. Vacuoles have a diverse array of functions. They can act as a storage organelle for nutrients or waste products, as a degradative compartment, as a cost-effective way of increasing cell size, and as a homeostatic regulator controlling both turgor pressure and pH of the cytosol." [GOC:mtg_sensu, ISBN:0198506732]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "vacuolar carboxypeptidase Y" RELATED []
+xref: Wikipedia:Vacuole
+is_a: GO:0043226 ! organelle
+relationship: part_of GO:0005737 ! cytoplasm
+
+[Term]
+id: GO:0005777
+name: peroxisome
+namespace: cellular_component
+alt_id: GO:0019818
+def: "A small organelle enclosed by a single membrane, and found in most eukaryotic cells. Contains peroxidases and other enzymes involved in a variety of metabolic processes including free radical detoxification, lipid catabolism and biosynthesis, and hydrogen peroxide metabolism." [GOC:pm, PMID:9302272, UniProtKB-KW:KW-0576]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_plant
+subset: goslim_yeast
+synonym: "peroxisomal" RELATED [GOC:curators]
+synonym: "peroxisome vesicle" BROAD []
+xref: NIF_Subcellular:sao499555322
+xref: Wikipedia:Peroxisome
+is_a: GO:0043226 ! organelle
+relationship: part_of GO:0005737 ! cytoplasm
+
+[Term]
+id: GO:0005783
+name: endoplasmic reticulum
+namespace: cellular_component
+def: "The irregular network of unit membranes, visible only by electron microscopy, that occurs in the cytoplasm of many eukaryotic cells. The membranes form a complex meshwork of tubular channels, which are often expanded into slitlike cavities called cisternae. The ER takes two forms, rough (or granular), with ribosomes adhering to the outer surface, and smooth (with no ribosomes attached)." [ISBN:0198506732]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+synonym: "ER" EXACT []
+xref: NIF_Subcellular:sao1036339110
+xref: Wikipedia:Endoplasmic_reticulum
+is_a: GO:0043226 ! organelle
+relationship: part_of GO:0005622 ! intracellular
+
+[Term]
+id: GO:0005794
+name: Golgi apparatus
+namespace: cellular_component
+def: "A compound membranous cytoplasmic organelle of eukaryotic cells, consisting of flattened, ribosome-free vesicles arranged in a more or less regular stack. The Golgi apparatus differs from the endoplasmic reticulum in often having slightly thicker membranes, appearing in sections as a characteristic shallow semicircle so that the convex side (cis or entry face) abuts the endoplasmic reticulum, secretory vesicles emerging from the concave side (trans or exit face). In vertebrate cells there is usually one such organelle, while in invertebrates and plants, where they are known usually as dictyosomes, there may be several scattered in the cytoplasm. The Golgi apparatus processes proteins produced on the ribosomes of the rough endoplasmic reticulum; such processing includes modification of the core oligosaccharides of glycoproteins, and the sorting and packaging of proteins for transport to a variety of cellular locations. Three different regions of the Golgi are now recognized both in terms of structure and function: cis, in the vicinity of the cis face, trans, in the vicinity of the trans face, and medial, lying between the cis and trans regions." [ISBN:0198506732]
+comment: Note that the Golgi apparatus can be located in various places in the cytoplasm. In plants and lower animal cells, the Golgi apparatus exists as many copies of discrete stacks dispersed throughout the cytoplasm, while the Golgi apparatus of interphase mammalian cells is a juxtanuclear, often pericentriolar reticulum, where the discrete Golgi stacks are stitched together to form a compact and interconnected ribbon, sometimes called the Golgi ribbon.
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+synonym: "Golgi" BROAD []
+synonym: "Golgi complex" EXACT []
+synonym: "Golgi ribbon" NARROW []
+xref: NIF_Subcellular:sao451912436
+xref: Wikipedia:Golgi_apparatus
+is_a: GO:0043226 ! organelle
+relationship: part_of GO:0005737 ! cytoplasm
+
+[Term]
+id: GO:0005811
+name: lipid droplet
+namespace: cellular_component
+def: "An intracellular non-membrane-bounded organelle comprising a matrix of coalesced lipids surrounded by a phospholipid monolayer. May include associated proteins." [GOC:mah, GOC:tb]
+comment: Note that this term does not refer to vesicles, but instead to structures in which lipids do not necessarily form bilayers.
+subset: goslim_chembl
+subset: goslim_generic
+synonym: "adiposome" EXACT []
+synonym: "lipid body" EXACT []
+synonym: "lipid particle" EXACT []
+is_a: GO:0043226 ! organelle
+relationship: part_of GO:0005622 ! intracellular
+
+[Term]
+id: GO:0005815
+name: microtubule organizing center
+namespace: cellular_component
+def: "An intracellular structure that can catalyze gamma-tubulin-dependent microtubule nucleation and that can anchor microtubules by interacting with their minus ends, plus ends or sides." [GOC:vw, http://en.wikipedia.org/wiki/Microtubule_organizing_center, ISBN:0815316194, PMID:17072892, PMID:17245416]
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+synonym: "microtubule organising centre" EXACT []
+synonym: "MTOC" EXACT []
+xref: Wikipedia:Microtubule_organizing_center
+is_a: GO:0005575 ! cellular_component
+relationship: part_of GO:0005856 ! cytoskeleton
+
+[Term]
+id: GO:0005829
+name: cytosol
+namespace: cellular_component
+def: "The part of the cytoplasm that does not contain organelles but which does contain other particulate matter, such as protein complexes." [GOC:hjd, GOC:jl]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_plant
+subset: gosubset_prok
+xref: NIF_Subcellular:sao101633890
+xref: Wikipedia:Cytosol
+is_a: GO:0005575 ! cellular_component
+relationship: part_of GO:0005737 ! cytoplasm
+
+[Term]
+id: GO:0005840
+name: ribosome
+namespace: cellular_component
+alt_id: GO:0033279
+def: "An intracellular organelle, about 200 A in diameter, consisting of RNA and protein. It is the site of protein biosynthesis resulting from translation of messenger RNA (mRNA). It consists of two subunits, one large and one small, each containing only protein and RNA. Both the ribosome and its subunits are characterized by their sedimentation coefficients, expressed in Svedberg units (symbol: S). Hence, the prokaryotic ribosome (70S) comprises a large (50S) subunit and a small (30S) subunit, while the eukaryotic ribosome (80S) comprises a large (60S) subunit and a small (40S) subunit. Two sites on the ribosomal large subunit are involved in translation, namely the aminoacyl site (A site) and peptidyl site (P site). Ribosomes from prokaryotes, eukaryotes, mitochondria, and chloroplasts have characteristically distinct ribosomal proteins." [ISBN:0198506732]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "free ribosome" NARROW [NIF_Subcellular:sao1139385046]
+synonym: "membrane bound ribosome" NARROW [NIF_Subcellular:sao1291545653]
+synonym: "ribosomal RNA" RELATED []
+xref: NIF_Subcellular:sao1429207766
+xref: Wikipedia:Ribosome
+is_a: GO:0043226 ! organelle
+relationship: part_of GO:0005737 ! cytoplasm
+
+[Term]
+id: GO:0005856
+name: cytoskeleton
+namespace: cellular_component
+def: "Any of the various filamentous elements that form the internal framework of cells, and typically remain after treatment of the cells with mild detergent to remove membrane constituents and soluble components of the cytoplasm. The term embraces intermediate filaments, microfilaments, microtubules, the microtrabecular lattice, and other structures characterized by a polymeric filamentous nature and long-range order within the cell. The various elements of the cytoskeleton not only serve in the maintenance of cellular shape but also have roles in other cellular functions, including cellular movement, cell division, endocytosis, and movement of organelles." [GOC:mah, ISBN:0198547684, PMID:16959967]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+xref: Wikipedia:Cytoskeleton
+is_a: GO:0043226 ! organelle
+relationship: part_of GO:0005622 ! intracellular
+
+[Term]
+id: GO:0005886
+name: plasma membrane
+namespace: cellular_component
+alt_id: GO:0005904
+def: "The membrane surrounding a cell that separates the cell from its external environment. It consists of a phospholipid bilayer and associated proteins." [ISBN:0716731363]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_mouse
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "bacterial inner membrane" NARROW []
+synonym: "cell membrane" EXACT []
+synonym: "cellular membrane" EXACT [NIF_Subcellular:sao6433132645]
+synonym: "cytoplasmic membrane" EXACT []
+synonym: "inner endospore membrane" NARROW []
+synonym: "juxtamembrane" BROAD []
+synonym: "plasma membrane lipid bilayer" NARROW [GOC:mah]
+synonym: "plasmalemma" EXACT []
+xref: NIF_Subcellular:sao1663586795
+xref: Wikipedia:Cell_membrane
+is_a: GO:0005575 ! cellular_component
+relationship: part_of GO:0005623 ! cell
+
+[Term]
+id: GO:0005929
+name: cilium
+namespace: cellular_component
+alt_id: GO:0072372
+def: "A specialized eukaryotic organelle that consists of a filiform extrusion of the cell surface and of some cytoplasmic parts. Each cilium is largely bounded by an extrusion of the cytoplasmic (plasma) membrane, and contains a regular longitudinal array of microtubules, anchored to a basal body." [GOC:cilia, GOC:curators, GOC:kmv, GOC:vw, ISBN:0198547684, PMID:16824949, PMID:17009929, PMID:20144998]
+comment: Note that we deem cilium and microtubule-based flagellum to be equivalent. In most eukaryotic species, intracellular sub-components of the cilium, such as the ciliary base and rootlet, are located near the plasma membrane. In Diplomonads such as Giardia, instead, the same ciliary parts are located further intracellularly. Also, 'cilium' may be used when axonemal structure and/or motility are unknown, or when axonemal structure is unusual. For all other cases, please refer to children of 'cilium'. Finally, note that any role of ciliary proteins in sensory events should be captured by annotating to relevant biological process terms.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+synonym: "eukaryotic flagellum" EXACT []
+synonym: "flagellum" RELATED []
+synonym: "microtubule-based flagellum" EXACT []
+synonym: "primary cilium" NARROW []
+xref: FMA:67181
+xref: NIF_Subcellular:sao787716553
+xref: Wikipedia:Cilium
+is_a: GO:0043226 ! organelle
+relationship: has_part GO:0043234 ! protein complex
+
+[Term]
+id: GO:0005975
+name: carbohydrate metabolic process
+namespace: biological_process
+alt_id: GO:0044723
+def: "The chemical reactions and pathways involving carbohydrates, any of a group of organic compounds based of the general formula Cx(H2O)y. Includes the formation of carbohydrate derivatives by the addition of a carbohydrate residue to another molecule." [GOC:mah, ISBN:0198506732]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_pombe
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "carbohydrate metabolism" EXACT []
+synonym: "single-organism carbohydrate metabolic process" RELATED []
+xref: Reactome:REACT_102834 "Metabolism of carbohydrates, Mus musculus"
+xref: Reactome:REACT_103806 "Metabolism of carbohydrates, Mycobacterium tuberculosis"
+xref: Reactome:REACT_104502 "Metabolism of carbohydrates, Gallus gallus"
+xref: Reactome:REACT_105321 "Metabolism of carbohydrates, Escherichia coli"
+xref: Reactome:REACT_106046 "Metabolism of carbohydrates, Drosophila melanogaster"
+xref: Reactome:REACT_107409 "Metabolism of carbohydrates, Caenorhabditis elegans"
+xref: Reactome:REACT_115733 "Carbohydrate metabolism, Gallus gallus"
+xref: Reactome:REACT_28218 "Metabolism of carbohydrates, Xenopus tropicalis"
+xref: Reactome:REACT_32291 "Metabolism of carbohydrates, Staphylococcus aureus N315"
+xref: Reactome:REACT_33141 "Metabolism of carbohydrates, Taeniopygia guttata"
+xref: Reactome:REACT_33953 "Metabolism of carbohydrates, Rattus norvegicus"
+xref: Reactome:REACT_34800 "Metabolism of carbohydrates, Danio rerio"
+xref: Reactome:REACT_474 "Metabolism of carbohydrates, Homo sapiens"
+xref: Reactome:REACT_77669 "Metabolism of carbohydrates, Plasmodium falciparum"
+xref: Reactome:REACT_81945 "Metabolism of carbohydrates, Schizosaccharomyces pombe"
+xref: Reactome:REACT_83038 "Metabolism of carbohydrates, Arabidopsis thaliana"
+xref: Reactome:REACT_83329 "Metabolism of carbohydrates, Saccharomyces cerevisiae"
+xref: Reactome:REACT_88330 "Metabolism of carbohydrates, Bos taurus"
+xref: Reactome:REACT_88558 "Metabolism of carbohydrates, Canis familiaris"
+xref: Reactome:REACT_90099 "Metabolism of carbohydrates, Sus scrofa"
+xref: Reactome:REACT_96375 "Metabolism of carbohydrates, Dictyostelium discoideum"
+xref: Reactome:REACT_98394 "Metabolism of carbohydrates, Oryza sativa"
+xref: Wikipedia:Carbohydrate_metabolism
+is_a: GO:0008150 ! biological_process
+created_by: janelomax
+creation_date: 2012-10-23T15:40:34Z
+
+[Term]
+id: GO:0006091
+name: generation of precursor metabolites and energy
+namespace: biological_process
+def: "The chemical reactions and pathways resulting in the formation of precursor metabolites, substances from which energy is derived, and any process involved in the liberation of energy from these substances." [GOC:jl]
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_pombe
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "energy pathways" BROAD []
+synonym: "intermediary metabolism" RELATED [GOC:mah]
+synonym: "metabolic energy generation" RELATED []
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0006259
+name: DNA metabolic process
+namespace: biological_process
+alt_id: GO:0055132
+def: "Any cellular metabolic process involving deoxyribonucleic acid. This is one of the two main types of nucleic acid, consisting of a long, unbranched macromolecule formed from one, or more commonly, two, strands of linked deoxyribonucleotides." [ISBN:0198506732]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "cellular DNA metabolism" EXACT []
+synonym: "DNA metabolism" EXACT []
+is_a: GO:0034641 ! cellular nitrogen compound metabolic process
+
+[Term]
+id: GO:0006397
+name: mRNA processing
+namespace: biological_process
+def: "Any process involved in the conversion of a primary mRNA transcript into one or more mature mRNA(s) prior to translation into polypeptide." [GOC:mah]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "mRNA maturation" RELATED []
+xref: Reactome:REACT_100203 "Processing of Capped Intronless Pre-mRNA, Dictyostelium discoideum"
+xref: Reactome:REACT_107308 "Processing of Capped Intronless Pre-mRNA, Xenopus tropicalis"
+xref: Reactome:REACT_109953 "Processing of Capped Intronless Pre-mRNA, Canis familiaris"
+xref: Reactome:REACT_113864 "Processing of Capped Intronless Pre-mRNA, Saccharomyces cerevisiae"
+xref: Reactome:REACT_114358 "Processing of Capped Intronless Pre-mRNA, Schizosaccharomyces pombe"
+xref: Reactome:REACT_115262 "Processing of Capped Intronless Pre-mRNA, Arabidopsis thaliana"
+xref: Reactome:REACT_1768 "Processing of Capped Intronless Pre-mRNA, Homo sapiens"
+xref: Reactome:REACT_32742 "Processing of Capped Intronless Pre-mRNA, Bos taurus"
+xref: Reactome:REACT_33642 "Processing of Capped Intronless Pre-mRNA, Caenorhabditis elegans"
+xref: Reactome:REACT_82691 "Processing of Capped Intronless Pre-mRNA, Gallus gallus"
+xref: Reactome:REACT_90366 "Processing of Capped Intronless Pre-mRNA, Drosophila melanogaster"
+xref: Reactome:REACT_91511 "Processing of Capped Intronless Pre-mRNA, Danio rerio"
+xref: Reactome:REACT_93186 "Processing of Capped Intronless Pre-mRNA, Sus scrofa"
+xref: Reactome:REACT_94083 "Processing of Capped Intronless Pre-mRNA, Taeniopygia guttata"
+xref: Reactome:REACT_96661 "Processing of Capped Intronless Pre-mRNA, Oryza sativa"
+xref: Reactome:REACT_97412 "Processing of Capped Intronless Pre-mRNA, Rattus norvegicus"
+xref: Reactome:REACT_97436 "Processing of Capped Intronless Pre-mRNA, Mus musculus"
+is_a: GO:0034641 ! cellular nitrogen compound metabolic process
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0006399
+name: tRNA metabolic process
+namespace: biological_process
+def: "The chemical reactions and pathways involving tRNA, transfer RNA, a class of relatively small RNA molecules responsible for mediating the insertion of amino acids into the sequence of nascent polypeptide chains during protein synthesis. Transfer RNA is characterized by the presence of many unusual minor bases, the function of which has not been completely established." [ISBN:0198506732]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pombe
+subset: gosubset_prok
+synonym: "tRNA metabolism" EXACT []
+is_a: GO:0034641 ! cellular nitrogen compound metabolic process
+
+[Term]
+id: GO:0006412
+name: translation
+namespace: biological_process
+alt_id: GO:0006416
+alt_id: GO:0006453
+alt_id: GO:0043037
+def: "The cellular metabolic process in which a protein is formed, using the sequence of a mature mRNA or circRNA molecule to specify the sequence of amino acids in a polypeptide chain. Translation is mediated by the ribosome, and begins with the formation of a ternary complex between aminoacylated initiator methionine tRNA, GTP, and initiation factor 2, which subsequently associates with the small subunit of the ribosome and an mRNA or circRNA. Translation ends with the release of a polypeptide chain from the ribosome." [GOC:go_curators]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "protein anabolism" EXACT []
+synonym: "protein biosynthesis" EXACT []
+synonym: "protein biosynthetic process" EXACT [GOC:curators]
+synonym: "protein formation" EXACT []
+synonym: "protein synthesis" EXACT []
+synonym: "protein translation" EXACT []
+xref: Reactome:REACT_100338 "Translation, Sus scrofa"
+xref: Reactome:REACT_100851 "Translation, Saccharomyces cerevisiae"
+xref: Reactome:REACT_101045 "Translation, Dictyostelium discoideum"
+xref: Reactome:REACT_101324 "Translation, Canis familiaris"
+xref: Reactome:REACT_1014 "Translation, Homo sapiens"
+xref: Reactome:REACT_103420 "Translation, Plasmodium falciparum"
+xref: Reactome:REACT_105544 "Translation, Arabidopsis thaliana"
+xref: Reactome:REACT_29980 "Translation, Bos taurus"
+xref: Reactome:REACT_33559 "Translation, Rattus norvegicus"
+xref: Reactome:REACT_77710 "Translation, Drosophila melanogaster"
+xref: Reactome:REACT_79784 "Translation, Danio rerio"
+xref: Reactome:REACT_81734 "Translation, Schizosaccharomyces pombe"
+xref: Reactome:REACT_81833 "Translation, Caenorhabditis elegans"
+xref: Reactome:REACT_82171 "Translation, Xenopus tropicalis"
+xref: Reactome:REACT_83429 "Translation, Taeniopygia guttata"
+xref: Reactome:REACT_83530 "Translation, Gallus gallus"
+xref: Reactome:REACT_86996 "Translation, Oryza sativa"
+xref: Reactome:REACT_95535 "Translation, Mus musculus"
+xref: Reactome:REACT_96394 "Translation, Escherichia coli"
+xref: Wikipedia:Translation_(genetics)
+is_a: GO:0009058 ! biosynthetic process
+is_a: GO:0034641 ! cellular nitrogen compound metabolic process
+relationship: has_part GO:0022618 ! ribonucleoprotein complex assembly
+
+[Term]
+id: GO:0006457
+name: protein folding
+namespace: biological_process
+alt_id: GO:0007022
+alt_id: GO:0007024
+alt_id: GO:0007025
+def: "The process of assisting in the covalent and noncovalent assembly of single chain polypeptides or multisubunit complexes into the correct tertiary structure." [GOC:go_curators, GOC:rb]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_pombe
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "alpha-tubulin folding" NARROW [GOC:mah]
+synonym: "beta-tubulin folding" NARROW [GOC:mah]
+synonym: "chaperone activity" RELATED []
+synonym: "chaperonin ATPase activity" RELATED []
+synonym: "chaperonin-mediated tubulin folding" NARROW [GOC:mah]
+synonym: "co-chaperone activity" RELATED []
+synonym: "co-chaperonin activity" RELATED []
+synonym: "glycoprotein-specific chaperone activity" RELATED []
+synonym: "non-chaperonin molecular chaperone ATPase activity" RELATED []
+synonym: "protein complex assembly, multichaperone pathway" RELATED []
+xref: Reactome:REACT_100411 "Chaperonin-mediated protein folding, Arabidopsis thaliana"
+xref: Reactome:REACT_104912 "Chaperonin-mediated protein folding, Caenorhabditis elegans"
+xref: Reactome:REACT_105663 "Chaperonin-mediated protein folding, Rattus norvegicus"
+xref: Reactome:REACT_106009 "Chaperonin-mediated protein folding, Canis familiaris"
+xref: Reactome:REACT_106427 "Chaperonin-mediated protein folding, Mus musculus"
+xref: Reactome:REACT_106894 "Formation of tubulin folding intermediates by CCT/TriC, Canis familiaris"
+xref: Reactome:REACT_106927 "Chaperonin-mediated protein folding, Drosophila melanogaster"
+xref: Reactome:REACT_107029 "Formation of tubulin folding intermediates by CCT/TriC, Drosophila melanogaster"
+xref: Reactome:REACT_108248 "Chaperonin-mediated protein folding, Gallus gallus"
+xref: Reactome:REACT_109411 "Formation of tubulin folding intermediates by CCT/TriC, Bos taurus"
+xref: Reactome:REACT_110417 "Formation of tubulin folding intermediates by CCT/TriC, Rattus norvegicus"
+xref: Reactome:REACT_16956 "Formation of tubulin folding intermediates by CCT/TriC, Homo sapiens"
+xref: Reactome:REACT_17001 "Formation of tubulin folding intermediates by CCT/TriC, Mus musculus"
+xref: Reactome:REACT_17004 "Chaperonin-mediated protein folding, Homo sapiens"
+xref: Reactome:REACT_17056 "Cooperation of Prefoldin and TriC/CCT in actin and tubulin folding, Bos taurus"
+xref: Reactome:REACT_23878 "N-glycan trimming in the ER and Calnexin/Calreticulin cycle, Homo sapiens"
+xref: Reactome:REACT_30906 "Chaperonin-mediated protein folding, Oryza sativa"
+xref: Reactome:REACT_32155 "Chaperonin-mediated protein folding, Saccharomyces cerevisiae"
+xref: Reactome:REACT_32255 "Chaperonin-mediated protein folding, Schizosaccharomyces pombe"
+xref: Reactome:REACT_33395 "Formation of tubulin folding intermediates by CCT/TriC, Mus musculus"
+xref: Reactome:REACT_77627 "Chaperonin-mediated protein folding, Plasmodium falciparum"
+xref: Reactome:REACT_77963 "Formation of tubulin folding intermediates by CCT/TriC, Saccharomyces cerevisiae"
+xref: Reactome:REACT_78530 "Formation of tubulin folding intermediates by CCT/TriC, Gallus gallus"
+xref: Reactome:REACT_81155 "Formation of tubulin folding intermediates by CCT/TriC, Caenorhabditis elegans"
+xref: Reactome:REACT_83906 "Chaperonin-mediated protein folding, Dictyostelium discoideum"
+xref: Reactome:REACT_85492 "Formation of tubulin folding intermediates by CCT/TriC, Sus scrofa"
+xref: Reactome:REACT_85496 "Formation of tubulin folding intermediates by CCT/TriC, Plasmodium falciparum"
+xref: Reactome:REACT_86318 "Formation of tubulin folding intermediates by CCT/TriC, Arabidopsis thaliana"
+xref: Reactome:REACT_91676 "Formation of tubulin folding intermediates by CCT/TriC, Schizosaccharomyces pombe"
+xref: Reactome:REACT_92785 "Formation of tubulin folding intermediates by CCT/TriC, Dictyostelium discoideum"
+xref: Reactome:REACT_92961 "Chaperonin-mediated protein folding, Xenopus tropicalis"
+xref: Reactome:REACT_92981 "Chaperonin-mediated protein folding, Taeniopygia guttata"
+xref: Reactome:REACT_94123 "Formation of tubulin folding intermediates by CCT/TriC, Taeniopygia guttata"
+xref: Reactome:REACT_94443 "Formation of tubulin folding intermediates by CCT/TriC, Danio rerio"
+xref: Reactome:REACT_94772 "Chaperonin-mediated protein folding, Sus scrofa"
+xref: Reactome:REACT_96773 "Chaperonin-mediated protein folding, Danio rerio"
+xref: Reactome:REACT_97016 "Chaperonin-mediated protein folding, Bos taurus"
+xref: Reactome:REACT_97220 "Formation of tubulin folding intermediates by CCT/TriC, Xenopus tropicalis"
+xref: Reactome:REACT_98132 "Formation of tubulin folding intermediates by CCT/TriC, Oryza sativa"
+xref: Wikipedia:Protein_folding
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0006461
+name: protein complex assembly
+namespace: biological_process
+def: "The aggregation, arrangement and bonding together of a set of components to form a protein complex." [GOC:ai]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pombe
+subset: gosubset_prok
+synonym: "chaperone activity" RELATED []
+synonym: "protein complex formation" EXACT []
+is_a: GO:0065003 ! macromolecular complex assembly
+
+[Term]
+id: GO:0006464
+name: cellular protein modification process
+namespace: biological_process
+def: "The covalent alteration of one or more amino acids occurring in proteins, peptides and nascent polypeptides (co-translational, post-translational modifications) occurring at the level of an individual cell. Includes the modification of charged tRNAs that are destined to occur in a protein (pre-translation modification)." [GOC:go_curators]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "process resulting in protein modification" RELATED []
+synonym: "protein modification process" BROAD [GOC:bf, GOC:jl]
+synonym: "protein tagging activity" RELATED []
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0006520
+name: cellular amino acid metabolic process
+namespace: biological_process
+alt_id: GO:0006519
+def: "The chemical reactions and pathways involving amino acids, carboxylic acids containing one or more amino groups, as carried out by individual cells." [CHEBI:33709, GOC:curators, ISBN:0198506732]
+subset: goslim_aspergillus
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pombe
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "amino acid and derivative metabolism" EXACT [GOC:curators]
+synonym: "amino acid metabolic process" EXACT [GOC:curators]
+synonym: "cellular amino acid and derivative metabolic process" EXACT []
+synonym: "cellular amino acid metabolism" EXACT []
+xref: Reactome:REACT_116093 "Amino acid metabolism, Gallus gallus"
+is_a: GO:0044281 ! small molecule metabolic process
+
+[Term]
+id: GO:0006605
+name: protein targeting
+namespace: biological_process
+def: "The process of targeting specific proteins to particular regions of the cell, typically membrane-bounded subcellular organelles. Usually requires an organelle specific protein sequence motif." [GOC:ma]
+comment: Note that protein targeting encompasses the transport of the protein to the specified location, and may also include additional steps such as protein processing.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pombe
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "nascent polypeptide association" RELATED []
+synonym: "protein sorting along secretory pathway" NARROW []
+xref: Wikipedia:Protein_targeting
+is_a: GO:0006810 ! transport
+relationship: occurs_in GO:0005622 ! intracellular
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0006629
+name: lipid metabolic process
+namespace: biological_process
+def: "The chemical reactions and pathways involving lipids, compounds soluble in an organic solvent but not, or sparingly, in an aqueous solvent. Includes fatty acids; neutral fats, other fatty-acid esters, and soaps; long-chain (fatty) alcohols and waxes; sphingoids and other long-chain bases; glycolipids, phospholipids and sphingolipids; and carotenes, polyprenols, sterols, terpenes and other isoprenoids." [GOC:ma]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_mouse
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_pombe
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "lipid metabolism" EXACT []
+xref: Reactome:REACT_104930 "Lipid digestion, mobilization, and transport, Drosophila melanogaster"
+xref: Reactome:REACT_107479 "Lipid digestion, mobilization, and transport, Xenopus tropicalis"
+xref: Reactome:REACT_108775 "Lipid digestion, mobilization, and transport, Canis familiaris"
+xref: Reactome:REACT_114669 "Lipid digestion, mobilization, and transport, Staphylococcus aureus N315"
+xref: Reactome:REACT_115652 "Lipid metabolism, Gallus gallus"
+xref: Reactome:REACT_28745 "Lipid digestion, mobilization, and transport, Saccharomyces cerevisiae"
+xref: Reactome:REACT_31395 "Lipid digestion, mobilization, and transport, Sus scrofa"
+xref: Reactome:REACT_32539 "Lipid digestion, mobilization, and transport, Bos taurus"
+xref: Reactome:REACT_33836 "Lipid digestion, mobilization, and transport, Rattus norvegicus"
+xref: Reactome:REACT_602 "Lipid digestion, mobilization, and transport, Homo sapiens"
+xref: Reactome:REACT_77176 "Lipid digestion, mobilization, and transport, Danio rerio"
+xref: Reactome:REACT_77191 "Lipid digestion, mobilization, and transport, Arabidopsis thaliana"
+xref: Reactome:REACT_79244 "Lipid digestion, mobilization, and transport, Plasmodium falciparum"
+xref: Reactome:REACT_81778 "Lipid digestion, mobilization, and transport, Oryza sativa"
+xref: Reactome:REACT_82512 "Lipid digestion, mobilization, and transport, Taeniopygia guttata"
+xref: Reactome:REACT_82723 "Lipid digestion, mobilization, and transport, Escherichia coli"
+xref: Reactome:REACT_87884 "Lipid digestion, mobilization, and transport, Caenorhabditis elegans"
+xref: Reactome:REACT_90757 "Lipid digestion, mobilization, and transport, Mus musculus"
+xref: Reactome:REACT_94607 "Lipid digestion, mobilization, and transport, Mycobacterium tuberculosis"
+xref: Reactome:REACT_97906 "Lipid digestion, mobilization, and transport, Gallus gallus"
+xref: Reactome:REACT_98129 "Lipid digestion, mobilization, and transport, Schizosaccharomyces pombe"
+xref: Reactome:REACT_99706 "Lipid digestion, mobilization, and transport, Dictyostelium discoideum"
+xref: Wikipedia:Lipid_metabolism
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0006790
+name: sulfur compound metabolic process
+namespace: biological_process
+def: "The chemical reactions and pathways involving the nonmetallic element sulfur or compounds that contain sulfur, such as the amino acids methionine and cysteine or the tripeptide glutathione." [GOC:ai]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pombe
+subset: gosubset_prok
+synonym: "sulfur metabolism" EXACT []
+synonym: "sulphur metabolic process" EXACT []
+synonym: "sulphur metabolism" EXACT []
+xref: Reactome:REACT_27247 "Sulfur compound metabolism, Mycobacterium tuberculosis"
+xref: Wikipedia:Sulfur_metabolism
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0006810
+name: transport
+namespace: biological_process
+alt_id: GO:0015457
+alt_id: GO:0015460
+alt_id: GO:0044765
+def: "The directed movement of substances (such as macromolecules, small molecules, ions) or cellular components (such as complexes and organelles) into, out of or within a cell, or between cells, or within a multicellular organism by means of some agent such as a transporter, pore or motor protein." [GOC:dos, GOC:dph, GOC:jl, GOC:mah]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "single-organism transport" RELATED []
+synonym: "small molecule transport" NARROW []
+synonym: "solute:solute exchange" NARROW []
+is_a: GO:0008150 ! biological_process
+created_by: janelomax
+creation_date: 2012-12-13T16:25:32Z
+
+[Term]
+id: GO:0006913
+name: nucleocytoplasmic transport
+namespace: biological_process
+alt_id: GO:0000063
+def: "The directed movement of molecules between the nucleus and the cytoplasm." [GOC:go_curators]
+comment: Note that transport through the nuclear pore complex is not transmembrane because the nuclear membrane is a double membrane, and is not traversed.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pombe
+synonym: "nucleocytoplasmic shuttling" NARROW []
+is_a: GO:0006810 ! transport
+relationship: occurs_in GO:0005622 ! intracellular
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0006914
+name: autophagy
+namespace: biological_process
+alt_id: GO:0016238
+def: "The cellular catabolic process in which cells digest parts of their own cytoplasm; allows for both recycling of macromolecular constituents under conditions of cellular stress and remodeling the intracellular structure for cell differentiation." [GOC:autophagy, ISBN:0198547684, PMID:11099404, PMID:9412464]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_pombe
+xref: Wikipedia:Autophagy_(cellular)
+is_a: GO:0009056 ! catabolic process
+relationship: has_part GO:0055085 ! transmembrane transport
+
+[Term]
+id: GO:0006950
+name: response to stress
+namespace: biological_process
+def: "Any process that results in a change in state or activity of a cell or an organism (in terms of movement, secretion, enzyme production, gene expression, etc.) as a result of a disturbance in organismal or cellular homeostasis, usually, but not necessarily, exogenous (e.g. temperature, humidity, ionizing radiation)." [GOC:mah]
+comment: Note that this term is in the subset of terms that should not be used for direct gene product annotation. Instead, select a child term or, if no appropriate child term exists, please request a new term. Direct annotations to this term may be amended during annotation QC.
+subset: gocheck_do_not_manually_annotate
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "response to abiotic stress" RELATED []
+synonym: "response to biotic stress" RELATED []
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0007005
+name: mitochondrion organization
+namespace: biological_process
+def: "A process that is carried out at the cellular level which results in the assembly, arrangement of constituent parts, or disassembly of a mitochondrion; includes mitochondrial morphogenesis and distribution, and replication of the mitochondrial genome as well as synthesis of new mitochondrial components." [GOC:dph, GOC:jl, GOC:mah, GOC:sgd_curators, PMID:9786946]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_pombe
+subset: goslim_yeast
+synonym: "mitochondria organization" EXACT [GOC:mah]
+synonym: "mitochondrion organisation" EXACT [GOC:mah]
+synonym: "mitochondrion organization and biogenesis" RELATED [GOC:curators]
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0007009
+name: plasma membrane organization
+namespace: biological_process
+def: "A process that is carried out at the cellular level which results in the assembly, arrangement of constituent parts, or disassembly of the plasma membrane." [GOC:dph, GOC:jl, GOC:mah]
+subset: goslim_chembl
+subset: goslim_generic
+subset: gosubset_prok
+synonym: "plasma membrane organisation" EXACT [GOC:curators]
+synonym: "plasma membrane organization and biogenesis" RELATED [GOC:mah]
+is_a: GO:0061024 ! membrane organization
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0007010
+name: cytoskeleton organization
+namespace: biological_process
+def: "A process that is carried out at the cellular level which results in the assembly, arrangement of constituent parts, or disassembly of cytoskeletal structures." [GOC:dph, GOC:jl, GOC:mah]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "cytoskeletal organization and biogenesis" RELATED [GOC:mah]
+synonym: "cytoskeletal regulator activity" RELATED []
+synonym: "cytoskeleton organisation" EXACT [GOC:curators]
+synonym: "cytoskeleton organization and biogenesis" RELATED [GOC:mah]
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0007034
+name: vacuolar transport
+namespace: biological_process
+def: "The directed movement of substances into, out of or within a vacuole." [GOC:ai]
+subset: goslim_chembl
+subset: goslim_generic
+is_a: GO:0006810 ! transport
+relationship: occurs_in GO:0005622 ! intracellular
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0007049
+name: cell cycle
+namespace: biological_process
+def: "The progression of biochemical and morphological phases and events that occur in a cell during successive cell replication or nuclear replication events. Canonically, the cell cycle comprises the replication and segregation of genetic material followed by the division of the cell, but in endocycles or syncytial cells nuclear replication or nuclear division may not be followed by cell division." [GOC:go_curators, GOC:mtg_cell_cycle]
+subset: gocheck_do_not_manually_annotate
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "cell-division cycle" EXACT []
+xref: Wikipedia:Cell_cycle
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0007059
+name: chromosome segregation
+namespace: biological_process
+def: "The process in which genetic material, in the form of chromosomes, is organized into specific structures and then physically separated and apportioned to two or more sets. In eukaryotes, chromosome segregation begins with the condensation of chromosomes, includes chromosome separation, and ends when chromosomes have completed movement to the spindle poles." [GOC:jl, GOC:mah, GOC:mtg_cell_cycle, GOC:vw]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "chromosome division" EXACT []
+synonym: "chromosome transmission" RELATED []
+xref: Wikipedia:Chromosome_segregation
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0007155
+name: cell adhesion
+namespace: biological_process
+alt_id: GO:0098602
+def: "The attachment of a cell, either to another cell or to an underlying substrate such as the extracellular matrix, via cell adhesion molecules." [GOC:hb, GOC:pf]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_pombe
+subset: gosubset_prok
+synonym: "cell adhesion molecule activity" RELATED []
+synonym: "single organism cell adhesion" RELATED []
+xref: Wikipedia:Cell_adhesion
+is_a: GO:0008150 ! biological_process
+created_by: davidos
+creation_date: 2014-04-15T15:59:10Z
+
+[Term]
+id: GO:0007165
+name: signal transduction
+namespace: biological_process
+alt_id: GO:0023033
+def: "The cellular process in which a signal is conveyed to trigger a change in the activity or state of a cell. Signal transduction begins with reception of a signal (e.g. a ligand binding to a receptor or receptor activation by a stimulus such as light), or for signal transduction in the absence of ligand, signal-withdrawal or the activity of a constitutively active receptor. Signal transduction ends with regulation of a downstream cellular process, e.g. regulation of transcription or regulation of a metabolic process. Signal transduction covers signaling from receptors located on the surface of the cell and signaling via molecules located within the cell. For signaling between cells, signal transduction is restricted to events at and within the receiving cell." [GOC:go_curators, GOC:mtg_signaling_feb11]
+comment: Note that signal transduction is defined broadly to include a ligand interacting with a receptor, downstream signaling steps and a response being triggered. A change in form of the signal in every step is not necessary. Note that in many cases the end of this process is regulation of the initiation of transcription. Note that specific transcription factors may be annotated to this term, but core/general transcription machinery such as RNA polymerase should not.
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "signaling cascade" NARROW []
+synonym: "signaling pathway" RELATED []
+synonym: "signalling cascade" NARROW []
+synonym: "signalling pathway" RELATED [GOC:mah]
+xref: Reactome:REACT_100624 "EGFR interacts with phospholipase C-gamma, Gallus gallus"
+xref: Reactome:REACT_102354 "EGFR interacts with phospholipase C-gamma, Canis familiaris"
+xref: Reactome:REACT_112130 "EGFR interacts with phospholipase C-gamma, Oryza sativa"
+xref: Reactome:REACT_112549 "EGFR interacts with phospholipase C-gamma, Arabidopsis thaliana"
+xref: Reactome:REACT_113151 "EGFR interacts with phospholipase C-gamma, Mycobacterium tuberculosis"
+xref: Reactome:REACT_113601 "EGFR interacts with phospholipase C-gamma, Drosophila melanogaster"
+xref: Reactome:REACT_113964 "EGFR interacts with phospholipase C-gamma, Bos taurus"
+xref: Reactome:REACT_114657 "EGFR interacts with phospholipase C-gamma, Dictyostelium discoideum"
+xref: Reactome:REACT_114690 "EGFR interacts with phospholipase C-gamma, Saccharomyces cerevisiae"
+xref: Reactome:REACT_114820 "EGFR interacts with phospholipase C-gamma, Sus scrofa"
+xref: Reactome:REACT_114910 "EGFR interacts with phospholipase C-gamma, Caenorhabditis elegans"
+xref: Reactome:REACT_115037 "EGFR interacts with phospholipase C-gamma, Plasmodium falciparum"
+xref: Reactome:REACT_115147 "EGFR interacts with phospholipase C-gamma, Schizosaccharomyces pombe"
+xref: Reactome:REACT_12478 "EGFR interacts with phospholipase C-gamma, Homo sapiens"
+xref: Reactome:REACT_31232 "EGFR interacts with phospholipase C-gamma, Rattus norvegicus"
+xref: Reactome:REACT_78535 "EGFR interacts with phospholipase C-gamma, Xenopus tropicalis"
+xref: Reactome:REACT_89740 "EGFR interacts with phospholipase C-gamma, Taeniopygia guttata"
+xref: Reactome:REACT_93680 "EGFR interacts with phospholipase C-gamma, Danio rerio"
+xref: Reactome:REACT_98872 "EGFR interacts with phospholipase C-gamma, Mus musculus"
+xref: Wikipedia:Signal_transduction
+is_a: GO:0008150 ! biological_process
+relationship: part_of GO:0008150 ! biological_process
+relationship: regulates GO:0008150 ! biological_process
+
+[Term]
+id: GO:0007267
+name: cell-cell signaling
+namespace: biological_process
+def: "Any process that mediates the transfer of information from one cell to another. This process includes signal transduction in the receiving cell and, where applicable, release of a ligand and any processes that actively facilitate its transport and presentation to the receiving cell.  Examples include signaling via soluble ligands, via cell adhesion molecules and via gap junctions." [GOC:dos, GOC:mah]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "cell-cell signalling" EXACT []
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0007568
+name: aging
+namespace: biological_process
+alt_id: GO:0016280
+def: "A developmental process that is a deterioration and loss of function over time. Aging includes loss of functions such as resistance to disease, homeostasis, and fertility, as well as wear and tear. Aging includes cellular senescence, but is more inclusive. May precede death and may succeed developmental maturation (GO:0021700)." [GOC:PO_curators]
+subset: goslim_chembl
+subset: goslim_generic
+synonym: "ageing" EXACT []
+xref: Wikipedia:Aging
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0008092
+name: cytoskeletal protein binding
+namespace: molecular_function
+def: "Interacting selectively and non-covalently with any protein component of any cytoskeleton (actin, microtubule, or intermediate filament cytoskeleton)." [GOC:mah]
+subset: goslim_agr
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_yeast
+subset: gosubset_prok
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0008134
+name: transcription factor binding
+namespace: molecular_function
+def: "Interacting selectively and non-covalently with a transcription factor, any protein required to initiate or regulate transcription." [ISBN:0198506732]
+subset: goslim_agr
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "TF binding" EXACT []
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0008135
+name: translation factor activity, RNA binding
+namespace: molecular_function
+def: "Functions during translation by interacting selectively and non-covalently with RNA during polypeptide synthesis at the ribosome." [GOC:ai, GOC:vw]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "translation factor activity, nucleic acid binding" BROAD [GOC:mah]
+is_a: GO:0003723 ! RNA binding
+relationship: part_of GO:0006412 ! translation
+
+[Term]
+id: GO:0008150
+name: biological_process
+namespace: biological_process
+alt_id: GO:0000004
+alt_id: GO:0007582
+alt_id: GO:0044699
+def: "Any process specifically pertinent to the functioning of integrated living units: cells, tissues, organs, and organisms. A process is a collection of molecular events with a defined beginning and end." [GOC:go_curators, GOC:isa_complete]
+comment: Note that, in addition to forming the root of the biological process ontology, this term is recommended for use for the annotation of gene products whose biological process is unknown. Note that when this term is used for annotation, it indicates that no information was available about the biological process of the gene product annotated as of the date the annotation was made; the evidence code ND, no data, is used to indicate this.
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_pombe
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "biological process" EXACT []
+synonym: "physiological process" EXACT []
+synonym: "single organism process" RELATED []
+synonym: "single-organism process" RELATED []
+xref: Wikipedia:Biological_process
+created_by: janelomax
+creation_date: 2012-09-19T15:05:24Z
+
+[Term]
+id: GO:0008168
+name: methyltransferase activity
+namespace: molecular_function
+alt_id: GO:0004480
+def: "Catalysis of the transfer of a methyl group to an acceptor molecule." [ISBN:0198506732]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "methylase" BROAD []
+xref: EC:2.1.1
+xref: Reactome:REACT_100745 "Methylation of 3,4-dihydroxypheylacetic acid to homovanillic acid, Bos taurus"
+xref: Reactome:REACT_100863 "methylation of Dopamine to form 3-Methoxytyramine, Taeniopygia guttata"
+xref: Reactome:REACT_100884 "methylation of Dopamine to form 3-Methoxytyramine, Xenopus tropicalis"
+xref: Reactome:REACT_103958 "methylation of Dopamine to form 3-Methoxytyramine, Rattus norvegicus"
+xref: Reactome:REACT_104757 "guanidinoacetate + S-adenosylmethionine => creatine + S-adenosylhomocysteine, Danio rerio"
+xref: Reactome:REACT_105478 "guanidinoacetate + S-adenosylmethionine => creatine + S-adenosylhomocysteine, Bos taurus"
+xref: Reactome:REACT_105909 "Methylation of 3,4-dihydroxypheylacetic acid to homovanillic acid, Xenopus tropicalis"
+xref: Reactome:REACT_106465 "Methylation of 3,4-dihydroxypheylacetic acid to homovanillic acid, Sus scrofa"
+xref: Reactome:REACT_107676 "Methylation of 3,4-dihydroxypheylacetic acid to homovanillic acid, Schizosaccharomyces pombe"
+xref: Reactome:REACT_15531 "methylation of Dopamine to form 3-Methoxytyramine, Homo sapiens"
+xref: Reactome:REACT_15553 "Methylation of 3,4-dihydroxypheylacetic acid to homovanillic acid, Homo sapiens"
+xref: Reactome:REACT_2094 "guanidinoacetate + S-adenosylmethionine => creatine + S-adenosylhomocysteine, Homo sapiens"
+xref: Reactome:REACT_29020 "methylation of Dopamine to form 3-Methoxytyramine, Bos taurus"
+xref: Reactome:REACT_29098 "guanidinoacetate + S-adenosylmethionine => creatine + S-adenosylhomocysteine, Canis familiaris"
+xref: Reactome:REACT_33644 "Methylation of 3,4-dihydroxypheylacetic acid to homovanillic acid, Mycobacterium tuberculosis"
+xref: Reactome:REACT_33779 "methylation of Dopamine to form 3-Methoxytyramine, Mycobacterium tuberculosis"
+xref: Reactome:REACT_73401 "guanidinoacetate + S-adenosylmethionine => creatine + S-adenosylhomocysteine, Rattus norvegicus"
+xref: Reactome:REACT_77286 "methylation of Dopamine to form 3-Methoxytyramine, Canis familiaris"
+xref: Reactome:REACT_78774 "guanidinoacetate + S-adenosylmethionine => creatine + S-adenosylhomocysteine, Mus musculus"
+xref: Reactome:REACT_79799 "Methylation of 3,4-dihydroxypheylacetic acid to homovanillic acid, Mus musculus"
+xref: Reactome:REACT_83214 "Methylation of 3,4-dihydroxypheylacetic acid to homovanillic acid, Gallus gallus"
+xref: Reactome:REACT_84525 "guanidinoacetate + S-adenosylmethionine => creatine + S-adenosylhomocysteine, Taeniopygia guttata"
+xref: Reactome:REACT_84974 "methylation of Dopamine to form 3-Methoxytyramine, Sus scrofa"
+xref: Reactome:REACT_86817 "methylation of Dopamine to form 3-Methoxytyramine, Schizosaccharomyces pombe"
+xref: Reactome:REACT_86905 "Methylation of 3,4-dihydroxypheylacetic acid to homovanillic acid, Rattus norvegicus"
+xref: Reactome:REACT_87169 "Methylation of 3,4-dihydroxypheylacetic acid to homovanillic acid, Taeniopygia guttata"
+xref: Reactome:REACT_93379 "methylation of Dopamine to form 3-Methoxytyramine, Gallus gallus"
+xref: Reactome:REACT_93809 "guanidinoacetate + S-adenosylmethionine => creatine + S-adenosylhomocysteine, Xenopus tropicalis"
+xref: Reactome:REACT_94274 "Methylation of 3,4-dihydroxypheylacetic acid to homovanillic acid, Canis familiaris"
+xref: Reactome:REACT_96444 "methylation of Dopamine to form 3-Methoxytyramine, Mus musculus"
+xref: Reactome:REACT_99316 "guanidinoacetate + S-adenosylmethionine => creatine + S-adenosylhomocysteine, Gallus gallus"
+is_a: GO:0003674 ! molecular_function
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0008219
+name: cell death
+namespace: biological_process
+def: "Any biological process that results in permanent cessation of all vital functions of a cell. A cell should be considered dead when any one of the following molecular or morphological criteria is met: (1) the cell has lost the integrity of its plasma membrane; (2) the cell, including its nucleus, has undergone complete fragmentation into discrete bodies (frequently referred to as apoptotic bodies). The cell corpse (or its fragments) may be engulfed by an adjacent cell in vivo, but engulfment of whole cells should not be considered a strict criteria to define cell death as, under some circumstances, live engulfed cells can be released from phagosomes (see PMID:18045538)." [GOC:mah, GOC:mtg_apoptosis, PMID:25236395]
+comment: This term should not be used for direct annotation. The only exception should be when experimental data (e.g., staining with trypan blue or propidium iodide) show that cell death has occurred, but fail to provide details on death modality (accidental versus programmed). When information is provided on the cell death mechanism, annotations should be made to the appropriate descendant of 'cell death' (such as, but not limited to, GO:0097300 'programmed necrotic cell death' or GO:0006915 'apoptotic process'). Also, if experimental data suggest that a gene product influences cell death indirectly, rather than being involved in the death process directly, consider annotating to a 'regulation' term.
+subset: goslim_agr
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "accidental cell death" RELATED []
+synonym: "necrosis" RELATED []
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0008233
+name: peptidase activity
+namespace: molecular_function
+def: "Catalysis of the hydrolysis of a peptide bond. A peptide bond is a covalent bond formed when the carbon atom from the carboxyl group of one amino acid shares electrons with the nitrogen atom from the amino group of a second amino acid." [GOC:jl, ISBN:0815332181]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "hydrolase, acting on peptide bonds" EXACT []
+synonym: "peptide hydrolase activity" EXACT []
+synonym: "protease activity" EXACT []
+synonym: "proteinase activity" NARROW []
+xref: EC:3.4
+xref: Reactome:REACT_106748 "gamma-secretase cleaves p75NTR, releasing NRIF and TRAF6, Rattus norvegicus"
+xref: Reactome:REACT_110349 "gamma-secretase cleaves p75NTR, releasing NRIF and TRAF6, Mus musculus"
+xref: Reactome:REACT_13710 "gamma-secretase cleaves p75NTR, releasing NRIF and TRAF6, Homo sapiens"
+xref: Reactome:REACT_19284 "Proteolytic processing of Slit, Homo sapiens"
+xref: Reactome:REACT_93020 "gamma-secretase cleaves p75NTR, releasing NRIF and TRAF6, Bos taurus"
+xref: Reactome:REACT_99630 "gamma-secretase cleaves p75NTR, releasing NRIF and TRAF6, Gallus gallus"
+is_a: GO:0003674 ! molecular_function
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0008283
+name: cell proliferation
+namespace: biological_process
+def: "The multiplication or reproduction of cells, resulting in the expansion of a cell population." [GOC:mah, GOC:mb]
+comment: This term was moved out from being a child of 'cellular process' because it is a cell population-level process, and cellular processes are restricted to those processes that involve individual cells. Also note that this term is intended to be used for the proliferation of cells within a multicellular organism, not for the expansion of a population of single-celled organisms.
+subset: goslim_agr
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_pir
+subset: gosubset_prok
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0008289
+name: lipid binding
+namespace: molecular_function
+def: "Interacting selectively and non-covalently with a lipid." [GOC:ai]
+subset: goslim_agr
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0008565
+name: protein transporter activity
+namespace: molecular_function
+alt_id: GO:0015463
+def: "Enables the directed movement of proteins into, out of or within a cell, or between cells." [ISBN:0198506732]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "enzyme transporter activity" NARROW []
+synonym: "holin" RELATED []
+synonym: "protein carrier activity" EXACT []
+synonym: "protein transport chaperone" NARROW [GOC:dph, GOC:mah, GOC:tb]
+synonym: "secretin" RELATED []
+is_a: GO:0003674 ! molecular_function
+relationship: part_of GO:0006810 ! transport
+
+[Term]
+id: GO:0009056
+name: catabolic process
+namespace: biological_process
+alt_id: GO:0044712
+def: "The chemical reactions and pathways resulting in the breakdown of substances, including the breakdown of carbon compounds with the liberation of energy for use by the cell or organism." [ISBN:0198547684]
+subset: goslim_agr
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "breakdown" EXACT []
+synonym: "catabolism" EXACT []
+synonym: "degradation" EXACT []
+synonym: "single-organism catabolic process" RELATED []
+xref: Wikipedia:Catabolism
+is_a: GO:0008150 ! biological_process
+created_by: janelomax
+creation_date: 2012-10-17T15:52:35Z
+
+[Term]
+id: GO:0009058
+name: biosynthetic process
+namespace: biological_process
+def: "The chemical reactions and pathways resulting in the formation of substances; typically the energy-requiring part of metabolism in which simpler substances are transformed into more complex ones." [GOC:curators, ISBN:0198547684]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "anabolism" EXACT []
+synonym: "biosynthesis" EXACT []
+synonym: "formation" EXACT []
+synonym: "synthesis" EXACT []
+xref: Wikipedia:Anabolism
+is_a: GO:0008150 ! biological_process
+created_by: janelomax
+creation_date: 2012-10-17T15:52:18Z
+
+[Term]
+id: GO:0009536
+name: plastid
+namespace: cellular_component
+def: "Any member of a family of organelles found in the cytoplasm of plants and some protists, which are membrane-bounded and contain DNA. Plant plastids develop from a common type, the proplastid." [GOC:jl, ISBN:0198547684]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_plant
+subset: gosubset_prok
+xref: Wikipedia:Plastid
+is_a: GO:0043226 ! organelle
+relationship: part_of GO:0005737 ! cytoplasm
+
+[Term]
+id: GO:0009579
+name: thylakoid
+namespace: cellular_component
+def: "A membranous cellular structure that bears the photosynthetic pigments in plants, algae, and cyanobacteria. In cyanobacteria thylakoids are of various shapes and are attached to, or continuous with, the plasma membrane. In eukaryotes they are flattened, membrane-bounded disk-like structures located in the chloroplasts; in the chloroplasts of higher plants the thylakoids form dense stacks called grana. Isolated thylakoid preparations can carry out photosynthetic electron transport and the associated phosphorylation." [GOC:ds, GOC:mtg_sensu, ISBN:0198506732]
+comment: A thylakoid is not considered an organelle, but some thylakoids are part of organelles.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "photosynthetic membrane" RELATED []
+xref: Wikipedia:Thylakoid
+is_a: GO:0005575 ! cellular_component
+relationship: part_of GO:0005622 ! intracellular
+
+[Term]
+id: GO:0009790
+name: embryo development
+namespace: biological_process
+alt_id: GO:0009795
+def: "The process whose specific outcome is the progression of an embryo from its formation until the end of its embryonic life stage. The end of the embryonic stage is organism-specific. For example, for mammals, the process would begin with zygote formation and end with birth. For insects, the process would begin at zygote formation and end with larval hatching. For plant zygotic embryos, this would be from zygote formation to the end of seed dormancy. For plant vegetative embryos, this would be from the initial determination of the cell or group of cells to form an embryo until the point when the embryo becomes independent of the parent plant." [GOC:go_curators, GOC:isa_complete, GOC:mtg_sensu]
+subset: gocheck_do_not_manually_annotate
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_plant
+synonym: "embryogenesis" EXACT []
+synonym: "embryogenesis and morphogenesis" BROAD []
+synonym: "embryonal development" EXACT []
+xref: Wikipedia:Embryogenesis
+is_a: GO:0048856 ! anatomical structure development
+
+[Term]
+id: GO:0015979
+name: photosynthesis
+namespace: biological_process
+def: "The synthesis by organisms of organic chemical compounds, especially carbohydrates, from carbon dioxide (CO2) using energy obtained from light rather than from the oxidation of chemical compounds." [ISBN:0198547684]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_plant
+subset: gosubset_prok
+xref: Wikipedia:Photosynthesis
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0016192
+name: vesicle-mediated transport
+namespace: biological_process
+alt_id: GO:0006899
+def: "A cellular transport process in which transported substances are moved in membrane-bounded vesicles; transported substances are enclosed in the vesicle lumen or located in the vesicle membrane. The process begins with a step that directs a substance to the forming vesicle, and includes vesicle budding and coating. Vesicles are then targeted to, and fuse with, an acceptor membrane." [GOC:ai, GOC:mah, ISBN:08789310662000]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_pombe
+subset: gosubset_prok
+synonym: "nonselective vesicle transport" NARROW []
+synonym: "protein sorting along secretory pathway" RELATED []
+synonym: "vesicle trafficking" RELATED []
+synonym: "vesicle transport" EXACT []
+synonym: "vesicular transport" EXACT [GOC:mah]
+is_a: GO:0006810 ! transport
+
+[Term]
+id: GO:0016301
+name: kinase activity
+namespace: molecular_function
+def: "Catalysis of the transfer of a phosphate group, usually from ATP, to a substrate molecule." [ISBN:0198506732]
+comment: Note that this term encompasses all activities that transfer a single phosphate group; although ATP is by far the most common phosphate donor, reactions using other phosphate donors are included in this term.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "phosphokinase activity" EXACT []
+xref: Reactome:REACT_100073 "Activation of S6K1, Schizosaccharomyces pombe"
+xref: Reactome:REACT_100078 "Wee1-mediated phosphorylation of Cyclin A:phospho-Cdc2 complexes, Canis familiaris"
+xref: Reactome:REACT_100159 "Inactivation of Myt1 kinase, Mus musculus"
+xref: Reactome:REACT_100260 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Taeniopygia guttata"
+xref: Reactome:REACT_100298 "Phosphorylation of L1 by CK-II, Rattus norvegicus"
+xref: Reactome:REACT_100305 "Regulation of NUDC by phosphorylation, Caenorhabditis elegans"
+xref: Reactome:REACT_100311 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Canis familiaris"
+xref: Reactome:REACT_100390 "Phosphorylation of phospho-(Ser45,Thr41,Ser37) at Ser33 by GSK-3, Canis familiaris"
+xref: Reactome:REACT_100465 "Phosphorylation and inactivation of eEF2K by activated S6K1, Dictyostelium discoideum"
+xref: Reactome:REACT_100495 "Cdc6 protein is phosphorylated by CDK, Xenopus tropicalis"
+xref: Reactome:REACT_100519 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Bos taurus"
+xref: Reactome:REACT_100636 "Phosphorylation of proteins involved in the G1/S transition by Cyclin A:Cdk2, Canis familiaris"
+xref: Reactome:REACT_100637 "Phosphorylation of the Scc1:Cohesion Complex, Mus musculus"
+xref: Reactome:REACT_101024 "Phosphorylation and inactivation of eEF2K by activated S6K1, Bos taurus"
+xref: Reactome:REACT_101170 "Phosphorylation of APC component of the destruction complex, Drosophila melanogaster"
+xref: Reactome:REACT_101303 "Activation of the Anaphase Promoting Complex (APC) by PLK1, Mus musculus"
+xref: Reactome:REACT_101431 "Mcm2-7 is phosphorylated by DDK, Danio rerio"
+xref: Reactome:REACT_101543 "CAK-mediated phosphorylation of Cyclin E:Cdk2, Canis familiaris"
+xref: Reactome:REACT_101596 "Phosphorylation of Cyclin D:Cdk4/6 complexes, Canis familiaris"
+xref: Reactome:REACT_101638 "Phosphorylation and activation of CHK2 by ATM, Bos taurus"
+xref: Reactome:REACT_101667 "Down Regulation of Emi1 through Phosphorylation of Emi1, Bos taurus"
+xref: Reactome:REACT_101841 "Phosphorylation of Cdc25C at Ser216, Rattus norvegicus"
+xref: Reactome:REACT_101862 "Myt-1 mediated phosphorylation of Cyclin A:Cdc2, Xenopus tropicalis"
+xref: Reactome:REACT_101914 "Wee1- mediated phosphorylation of Cyclin B1:phospho-Cdc2 complexes, Xenopus tropicalis"
+xref: Reactome:REACT_102090 "Phosphoryation of phospho- (Ser45, Thr41) beta-catenin at Ser37 by GSK-3, Taeniopygia guttata"
+xref: Reactome:REACT_102093 "Phosphorylation and activation of eIF4G by activated S6K1, Danio rerio"
+xref: Reactome:REACT_102154 "Autophosphorylation of PAK-2p34 in the activation loop, Schizosaccharomyces pombe"
+xref: Reactome:REACT_102322 "RAF1 phosphorylates MEK2, Danio rerio"
+xref: Reactome:REACT_102330 "Phosphorylation of MDM2 at serine-395 by ATM kinase, Xenopus tropicalis"
+xref: Reactome:REACT_102380 "Regulation of KIF23 (MKLP1) by phosphorylation, Xenopus tropicalis"
+xref: Reactome:REACT_102475 "Inactivation of Myt1 kinase, Rattus norvegicus"
+xref: Reactome:REACT_102499 "CAK-mediated phosphorylation of Cyclin A:Cdc2 complexes, Canis familiaris"
+xref: Reactome:REACT_102552 "Phosphorylation of Cdc25A at Ser-123 in response to DNA damage, Canis familiaris"
+xref: Reactome:REACT_102607 "Phosphorylation of Cdc25A at Ser-123 in response to DNA damage, Drosophila melanogaster"
+xref: Reactome:REACT_102711 "Phosphorylation of L1 by CK-II, Caenorhabditis elegans"
+xref: Reactome:REACT_102729 "RAF1 phosphorylates MEK1, Xenopus tropicalis"
+xref: Reactome:REACT_102817 "Phosphorylation of L1 by ERK, Mus musculus"
+xref: Reactome:REACT_102887 "Mcm2-7 is phosphorylated by DDK, Rattus norvegicus"
+xref: Reactome:REACT_102908 "Phosphorylation of the Scc1:Cohesion Complex, Rattus norvegicus"
+xref: Reactome:REACT_102915 "Activation of S6K1, Arabidopsis thaliana"
+xref: Reactome:REACT_103060 "Phosphorylation of MDC1/NFBD1 by ATM (within 2 c-term BRCT domains), Arabidopsis thaliana"
+xref: Reactome:REACT_103291 "Phosphorylation of complexed TSC2 by PKB, Drosophila melanogaster"
+xref: Reactome:REACT_103327 "Phosphorylation of Cyclin E2:Cdk2 complexes by Myt1, Rattus norvegicus"
+xref: Reactome:REACT_103359 "Wee1- mediated phosphorylation of Cyclin B1:phospho-Cdc2 complexes, Danio rerio"
+xref: Reactome:REACT_103468 "Activation of Cdc25C, Drosophila melanogaster"
+xref: Reactome:REACT_103691 "Phosphorylation of COP1 at Ser-387 by ATM, Xenopus tropicalis"
+xref: Reactome:REACT_103727 "Phosphorylation of NBS1 by ATM, Drosophila melanogaster"
+xref: Reactome:REACT_103804 "Phosphorylation of AKT2 by PDK1, Canis familiaris"
+xref: Reactome:REACT_103989 "Phosphorylation of NBS1 by ATM, Danio rerio"
+xref: Reactome:REACT_104022 "Phosphorylation of p53 at ser-15 by ATM kinase, Xenopus tropicalis"
+xref: Reactome:REACT_104044 "Phosphorylation and activation of Chk1 by ATM, Sus scrofa"
+xref: Reactome:REACT_104109 "Phosphorylation of proteins involved in the G1/S transition by Cyclin A:Cdk2, Danio rerio"
+xref: Reactome:REACT_104209 "Activation of S6K1, Caenorhabditis elegans"
+xref: Reactome:REACT_104323 "Wee1-mediated phosphorylation of Cyclin A:phospho-Cdc2 complexes, Rattus norvegicus"
+xref: Reactome:REACT_104386 "Phosphorylation and activation of eIF4B by activated S6K1, Bos taurus"
+xref: Reactome:REACT_104523 "Inactivation of Wee1 kinase, Bos taurus"
+xref: Reactome:REACT_104644 "Regulation of KIF20A (MKL2) by phosphorylation, Bos taurus"
+xref: Reactome:REACT_104687 "Phosphorylation of L1 by CK-II, Canis familiaris"
+xref: Reactome:REACT_104730 "Activation of the Anaphase Promoting Complex (APC) by PLK1, Schizosaccharomyces pombe"
+xref: Reactome:REACT_104822 "Phosphorylation of COP1 at Ser-387 by ATM, Rattus norvegicus"
+xref: Reactome:REACT_104837 "SOS phosphorylation and dissociation (SHC), Mus musculus"
+xref: Reactome:REACT_104878 "Phosphorylation of Cyclin E:Cdk2 complexes by Wee-1, Xenopus tropicalis"
+xref: Reactome:REACT_105254 "Phosphorylation of Cyclin E:Cdk2 complexes by Wee-1, Danio rerio"
+xref: Reactome:REACT_105274 "Regulation of KIF20A (MKL2) by phosphorylation, Danio rerio"
+xref: Reactome:REACT_105345 "Phosphoryation of phospho- (Ser45, Thr41) beta-catenin at Ser37 by GSK-3, Drosophila melanogaster"
+xref: Reactome:REACT_105373 "Phosphorylation of phospho-(Ser45 ) at Thr 41 by GSK-3, Gallus gallus"
+xref: Reactome:REACT_105503 "Phosphorylation of L1 by ERK, Bos taurus"
+xref: Reactome:REACT_105561 "Phosphorylation of complexed TSC2 by PKB, Xenopus tropicalis"
+xref: Reactome:REACT_105569 "CAK-mediated phosphorylation of Cyclin A:Cdc2 complexes, Xenopus tropicalis"
+xref: Reactome:REACT_105589 "Phosphorylation of p53 at ser-15 by ATM kinase, Canis familiaris"
+xref: Reactome:REACT_105664 "Akt1 phosphorylates BAD protein, Rattus norvegicus"
+xref: Reactome:REACT_105700 "Phosphorylation of PDE3B, Rattus norvegicus"
+xref: Reactome:REACT_105971 "Phosphorylation of Cyclin A:Cdk2 at Tyr 15, Xenopus tropicalis"
+xref: Reactome:REACT_105976 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Xenopus tropicalis"
+xref: Reactome:REACT_106075 "Akt1 phosphorylates BAD protein, Canis familiaris"
+xref: Reactome:REACT_106144 "Phosphorylation of Cyclin E1:Cdk2 complexes by Myt1, Xenopus tropicalis"
+xref: Reactome:REACT_106159 "Wee1- mediated phosphorylation of Cyclin B1:phospho-Cdc2 complexes, Canis familiaris"
+xref: Reactome:REACT_106186 "Phosphorylation of TSC2 by PKB, Drosophila melanogaster"
+xref: Reactome:REACT_106225 "Activation of the Anaphase Promoting Complex (APC) by PLK1, Canis familiaris"
+xref: Reactome:REACT_1063 "Phosphorylation of Wee1 kinase by Chk1, Schizosaccharomyces pombe"
+xref: Reactome:REACT_106324 "Activation of Cdc25C, Mus musculus"
+xref: Reactome:REACT_106383 "Phosphorylation of L1 by ERK, Xenopus tropicalis"
+xref: Reactome:REACT_106411 "Phosphorylation and inactivation of eEF2K by activated S6K1, Gallus gallus"
+xref: Reactome:REACT_106420 "Regulation of KIF23 (MKLP1) by phosphorylation, Taeniopygia guttata"
+xref: Reactome:REACT_106500 "Phosphorylation of Cdc25A at Ser-123 by Chk2, Drosophila melanogaster"
+xref: Reactome:REACT_106505 "Phosphorylation of histone H2AX at Serine-139 by ATM at the site of DSB, Rattus norvegicus"
+xref: Reactome:REACT_106514 "Phosphorylation of NBS1 by ATM, Mus musculus"
+xref: Reactome:REACT_106567 "CAK-mediated phosphorylation of Cyclin E:Cdk2, Mus musculus"
+xref: Reactome:REACT_106599 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Xenopus tropicalis"
+xref: Reactome:REACT_106681 "Phosphorylation of Cyclin A:Cdk2 at Tyr 15, Rattus norvegicus"
+xref: Reactome:REACT_106722 "CAK-mediated phosphorylation of Cyclin E:Cdk2, Xenopus tropicalis"
+xref: Reactome:REACT_106738 "SOS phosphorylation and dissociation (IRS, Crk), Canis familiaris"
+xref: Reactome:REACT_106897 "CAK-mediated phosphorylation of Cyclin E:Cdk2, Danio rerio"
+xref: Reactome:REACT_107009 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Arabidopsis thaliana"
+xref: Reactome:REACT_107055 "Phosphorylation of Cdc25C at Ser216, Bos taurus"
+xref: Reactome:REACT_107102 "SOS phosphorylation and dissociation (IRS, Crk), Danio rerio"
+xref: Reactome:REACT_107243 "Phosphorylation of APC component of the destruction complex, Mus musculus"
+xref: Reactome:REACT_107247 "Phosphorylation of TSC2 by PKB, Mus musculus"
+xref: Reactome:REACT_107310 "CAK-mediated phosphorylation of Cyclin A:Cdc2 complexes, Danio rerio"
+xref: Reactome:REACT_107424 "Inactivation of Myt1 kinase, Canis familiaris"
+xref: Reactome:REACT_107623 "Phosphorylation of histone H2AX at Serine-139 by ATM at the site of DSB, Mus musculus"
+xref: Reactome:REACT_107685 "Phosphorylation of Cyclin E:Cdk2 complexes by Wee-1, Sus scrofa"
+xref: Reactome:REACT_107732 "Phosphorylation of the Emi1 DSGxxS degron by Plk1, Danio rerio"
+xref: Reactome:REACT_107736 "Phosphorylation of Cdc25C at Ser216, Sus scrofa"
+xref: Reactome:REACT_107787 "Phosphorylation and activation of CHK2 by ATM, Drosophila melanogaster"
+xref: Reactome:REACT_107849 "Phosphorylation of DLC2 by MAPK-8, Bos taurus"
+xref: Reactome:REACT_107854 "Phosphorylation of Cyclin D1 at T286 by glycogen synthase kinase-3 beta, Canis familiaris"
+xref: Reactome:REACT_108002 "Plk1-mediated phosphorylation of Nlp, Bos taurus"
+xref: Reactome:REACT_108096 "Phosphorylation of beta-catenin at Ser45 by CK1 alpha, Rattus norvegicus"
+xref: Reactome:REACT_108132 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Gallus gallus"
+xref: Reactome:REACT_108362 "Phosphorylation of proteins involved in the G1/S transition by Cyclin A:Cdk2, Mus musculus"
+xref: Reactome:REACT_108394 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Danio rerio"
+xref: Reactome:REACT_108520 "Phosphorylation and activation of Chk1 by ATM, Danio rerio"
+xref: Reactome:REACT_108578 "Inactivation of Myt1 kinase, Xenopus tropicalis"
+xref: Reactome:REACT_108776 "Free APC/C phosphorylated by Plk1, Taeniopygia guttata"
+xref: Reactome:REACT_108840 "Phosphorylation of beta-catenin at Ser45 by CK1 alpha, Canis familiaris"
+xref: Reactome:REACT_108871 "Free APC/C phosphorylated by Plk1, Mus musculus"
+xref: Reactome:REACT_108971 "Phosphorylation of Cyclin B1 in the CRS domain, Xenopus tropicalis"
+xref: Reactome:REACT_108985 "Phosphorylation of cPLA2 by ERK-2, Gallus gallus"
+xref: Reactome:REACT_109045 "Phosphorylation of Cyclin E1:Cdk2 complexes by Myt1, Danio rerio"
+xref: Reactome:REACT_109065 "Phosphorylation of Cdc25A at Ser-123 by Chk2, Taeniopygia guttata"
+xref: Reactome:REACT_109117 "Phosphorylation of 4E-BP1 by activated mTORC1, Dictyostelium discoideum"
+xref: Reactome:REACT_109197 "SOS phosphorylation and dissociation (IRS), Mus musculus"
+xref: Reactome:REACT_109244 "Inactivation of Myt1 kinase, Schizosaccharomyces pombe"
+xref: Reactome:REACT_109260 "Free APC/C phosphorylated by Plk1, Xenopus tropicalis"
+xref: Reactome:REACT_109264 "SOS phosphorylation and dissociation (IRS), Canis familiaris"
+xref: Reactome:REACT_109331 "Activation of the Anaphase Promoting Complex (APC) by PLK1, Drosophila melanogaster"
+xref: Reactome:REACT_109367 "Phosphorylation of APC component of the destruction complex, Gallus gallus"
+xref: Reactome:REACT_109549 "Regulation of KIF20A (MKL2) by phosphorylation, Xenopus tropicalis"
+xref: Reactome:REACT_109641 "CAK-mediated phosphorylation of Cyclin A:Cdk2, Sus scrofa"
+xref: Reactome:REACT_109769 "Free APC/C phosphorylated by Plk1, Gallus gallus"
+xref: Reactome:REACT_109799 "Phosphorylation of Cyclin E:Cdk2 complexes by Wee-1, Mus musculus"
+xref: Reactome:REACT_110175 "Phosphorylation of MDC1/NFBD1 by ATM (within 2 c-term BRCT domains), Mus musculus"
+xref: Reactome:REACT_110254 "Phosphorylation of APC component of the destruction complex, Rattus norvegicus"
+xref: Reactome:REACT_110296 "Phosphorylation and activation of Chk1 by ATM, Schizosaccharomyces pombe"
+xref: Reactome:REACT_110351 "Phosphorylation and inactivation of eEF2K by activated S6K1, Canis familiaris"
+xref: Reactome:REACT_110382 "Phosphorylation of MDC1/NFBD1 by ATM (within 2 c-term BRCT domains), Oryza sativa"
+xref: Reactome:REACT_110530 "Down Regulation of Emi1 through Phosphorylation of Emi1, Mus musculus"
+xref: Reactome:REACT_110583 "Phosphorylation of DLC2 by MAPK-8, Mus musculus"
+xref: Reactome:REACT_110643 "Mcm2-7 is phosphorylated by DDK, Xenopus tropicalis"
+xref: Reactome:REACT_110679 "Phosphorylation of histone H2AX at Serine-139 by ATM at the site of DSB, Danio rerio"
+xref: Reactome:REACT_110774 "Inactivation of Myt1 kinase, Drosophila melanogaster"
+xref: Reactome:REACT_110775 "Phosphorylation of Cdc25A at Ser-123 in response to DNA damage, Rattus norvegicus"
+xref: Reactome:REACT_110947 "Regulation of KIF23 (MKLP1) by phosphorylation, Drosophila melanogaster"
+xref: Reactome:REACT_110995 "Phosphorylation and activation of eIF4G by activated S6K1, Xenopus tropicalis"
+xref: Reactome:REACT_111124 "FGFR associated PI3K phosphorylates PIP2 to PIP3, Homo sapiens"
+xref: Reactome:REACT_111171 "FGFR-associated PI3K phosphorylates PIP2 to PIP3, Homo sapiens"
+xref: Reactome:REACT_1116 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Homo sapiens"
+xref: Reactome:REACT_111930 "Phosphorylation of Cdc25A at Ser-123 by Chk2, Caenorhabditis elegans"
+xref: Reactome:REACT_1120 "Regulation of KIF20A (MKL2) by phosphorylation, Homo sapiens"
+xref: Reactome:REACT_112075 "Mcm2-7 is phosphorylated by DDK, Drosophila melanogaster"
+xref: Reactome:REACT_112101 "Phosphorylation of L1 by CK-II, Xenopus tropicalis"
+xref: Reactome:REACT_112156 "Phosphorylation of AKT2 by PDK1, Saccharomyces cerevisiae"
+xref: Reactome:REACT_112214 "Hyperphosphorylation (Ser2) of RNA Pol II CTD by P-TEFb complex, Schizosaccharomyces pombe"
+xref: Reactome:REACT_112270 "Akt1 phosphorylates BAD protein, Xenopus tropicalis"
+xref: Reactome:REACT_112298 "Autophosphorylation of DNA-PKcs, Dictyostelium discoideum"
+xref: Reactome:REACT_112324 "Phosphorylation and activation of eIF4G by activated S6K1, Oryza sativa"
+xref: Reactome:REACT_112360 "Regulation of KIF23 (MKLP1) by phosphorylation, Dictyostelium discoideum"
+xref: Reactome:REACT_112413 "Phosphorylation of Cdc25A at Ser-123 by Chk2, Saccharomyces cerevisiae"
+xref: Reactome:REACT_112480 "Inactivation of Wee1 kinase, Dictyostelium discoideum"
+xref: Reactome:REACT_112545 "Phosphorylation and activation of eIF4G by activated S6K1, Drosophila melanogaster"
+xref: Reactome:REACT_112633 "CAK-mediated phosphorylation of Cyclin E:Cdk2, Saccharomyces cerevisiae"
+xref: Reactome:REACT_112709 "Phosphorylation of L1 by ERK, Saccharomyces cerevisiae"
+xref: Reactome:REACT_112722 "Hyperphosphorylation (Ser2) of RNA Pol II CTD by P-TEFb complex, Drosophila melanogaster"
+xref: Reactome:REACT_112790 "Phosphorylation of Cdc25A at Ser-123 in response to DNA damage, Caenorhabditis elegans"
+xref: Reactome:REACT_112846 "Phosphorylation of Cyclin E1:Cdk2 complexes by Myt1, Saccharomyces cerevisiae"
+xref: Reactome:REACT_112892 "Phosphorylation of BRCA1 at multiple sites by ATM, Oryza sativa"
+xref: Reactome:REACT_112948 "Autophosphorylation of DNA-PKcs, Rattus norvegicus"
+xref: Reactome:REACT_113022 "Phosphorylation of Cyclin B1 in the CRS domain, Schizosaccharomyces pombe"
+xref: Reactome:REACT_113051 "Phosphorylation of Cyclin D1 at T286 by glycogen synthase kinase-3 beta, Arabidopsis thaliana"
+xref: Reactome:REACT_113121 "Phosphorylation and activation of eIF4B by activated S6K1, Schizosaccharomyces pombe"
+xref: Reactome:REACT_113227 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Saccharomyces cerevisiae"
+xref: Reactome:REACT_113244 "CAK-mediated phosphorylation of Cyclin E:Cdk2, Drosophila melanogaster"
+xref: Reactome:REACT_113269 "Activation of S6K1, Saccharomyces cerevisiae"
+xref: Reactome:REACT_113435 "Phosphorylation of Cyclin D1 at T286 by glycogen synthase kinase-3 beta, Oryza sativa"
+xref: Reactome:REACT_113527 "Autophosphorylation of DNA-PKcs, Bos taurus"
+xref: Reactome:REACT_113569 "Activation of Cdc25C, Saccharomyces cerevisiae"
+xref: Reactome:REACT_113811 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Bos taurus"
+xref: Reactome:REACT_113820 "Phosphorylation of Cyclin B1 in the CRS domain, Saccharomyces cerevisiae"
+xref: Reactome:REACT_113894 "PIP2 conversion to PIP3, Caenorhabditis elegans"
+xref: Reactome:REACT_113929 "Phosphorylation of Cdc25A at Ser-123 by Chk1, Caenorhabditis elegans"
+xref: Reactome:REACT_113990 "Activation of Cdc25C, Schizosaccharomyces pombe"
+xref: Reactome:REACT_114160 "CAK-mediated phosphorylation of Cyclin B1:Cdc2 complexes, Saccharomyces cerevisiae"
+xref: Reactome:REACT_114198 "Phosphorylation of the Scc1:Cohesion Complex, Schizosaccharomyces pombe"
+xref: Reactome:REACT_114207 "Phosphorylation of Cdc25A at Ser-123 by Chk1, Schizosaccharomyces pombe"
+xref: Reactome:REACT_114227 "Phosphorylation of Cyclin E1:Cdk2 complexes by Myt1, Schizosaccharomyces pombe"
+xref: Reactome:REACT_114233 "Autophosphorylation of DNA-PKcs, Sus scrofa"
+xref: Reactome:REACT_114255 "Autophosphorylation of DNA-PKcs, Mus musculus"
+xref: Reactome:REACT_114268 "Phosphorylation of Cdc25A at Ser-123 in response to DNA damage, Schizosaccharomyces pombe"
+xref: Reactome:REACT_114280 "Phosphorylation of Cdc25A at Ser-123 in response to DNA damage, Saccharomyces cerevisiae"
+xref: Reactome:REACT_114319 "Hyperphosphorylation (Ser2) of RNA Pol II CTD by P-TEFb complex, Caenorhabditis elegans"
+xref: Reactome:REACT_114323 "Activation of Cdc25C, Caenorhabditis elegans"
+xref: Reactome:REACT_114395 "Phosphorylation of DLC1 by MAPK 8, Xenopus tropicalis"
+xref: Reactome:REACT_114434 "Autophosphorylation of DNA-PKcs, Taeniopygia guttata"
+xref: Reactome:REACT_114461 "Phosphorylation of AKT2 by PDK1, Schizosaccharomyces pombe"
+xref: Reactome:REACT_114522 "Phosphorylation of BRCA1 at multiple sites by ATM, Arabidopsis thaliana"
+xref: Reactome:REACT_114553 "Phosphorylation of Cdc25A at Ser-123 by Chk1, Saccharomyces cerevisiae"
+xref: Reactome:REACT_114599 "Phosphorylation of TSC2 by PKB, Schizosaccharomyces pombe"
+xref: Reactome:REACT_114624 "Phosphorylation of Cyclin E1:Cdk2 complexes by Myt1, Drosophila melanogaster"
+xref: Reactome:REACT_114771 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Canis familiaris"
+xref: Reactome:REACT_114906 "Phosphorylation and activation of eIF4G by activated S6K1, Arabidopsis thaliana"
+xref: Reactome:REACT_114984 "Autophosphorylation of DNA-PKcs, Xenopus tropicalis"
+xref: Reactome:REACT_115006 "Phosphorylation of Cyclin D1 at T286 by glycogen synthase kinase-3 beta, Caenorhabditis elegans"
+xref: Reactome:REACT_115135 "Phosphorylation and activation of eIF4G by activated S6K1, Dictyostelium discoideum"
+xref: Reactome:REACT_115168 "Autophosphorylation of DNA-PKcs, Gallus gallus"
+xref: Reactome:REACT_115199 "Autophosphorylation of DNA-PKcs, Canis familiaris"
+xref: Reactome:REACT_115358 "Phosphorylation of Cyclin E:Cdk2 complexes by Wee-1, Drosophila melanogaster"
+xref: Reactome:REACT_115384 "CAK-mediated phosphorylation of Cyclin B1:Cdc2 complexes, Schizosaccharomyces pombe"
+xref: Reactome:REACT_115440 "Hyperphosphorylation (Ser2) of RNA Pol II CTD by P-TEFb complex, Danio rerio"
+xref: Reactome:REACT_115472 "Phosphorylation of the SA2 Cohesin Complex, Schizosaccharomyces pombe"
+xref: Reactome:REACT_115475 "CAK-mediated phosphorylation of Cyclin E:Cdk2, Schizosaccharomyces pombe"
+xref: Reactome:REACT_115521 "Autophosphorylation of DNA-PKcs, Danio rerio"
+xref: Reactome:REACT_115527 "Phosphorylation of Cdc25A at Ser-123 by Chk2, Schizosaccharomyces pombe"
+xref: Reactome:REACT_115747 "Phosphorylation of H2AX at S139 by ATM at the site of DSB, Gallus gallus"
+xref: Reactome:REACT_116149 "Phosphorylation of RAD51 by tyrosine kinase Abelson family protein members, Gallus gallus"
+xref: Reactome:REACT_118137 "Phosphorylation of the Scc1:Cohesion Complex, Taeniopygia guttata"
+xref: Reactome:REACT_118229 "Phosphorylation of the SA2 Cohesin Complex, Taeniopygia guttata"
+xref: Reactome:REACT_118284 "Phosphorylation of the Scc1:Cohesion Complex, Saccharomyces cerevisiae"
+xref: Reactome:REACT_118307 "Phosphorylation of the SA2 Cohesin Complex, Gallus gallus"
+xref: Reactome:REACT_118367 "Phosphorylation of the Scc1:Cohesion Complex, Gallus gallus"
+xref: Reactome:REACT_118462 "Phosphorylation of the SA2 Cohesin Complex, Saccharomyces cerevisiae"
+xref: Reactome:REACT_1185 "Phosphorylation (Ser5) of RNA pol II CTD, Homo sapiens"
+xref: Reactome:REACT_1279 "Cdc6 protein is phosphorylated by CDK, Homo sapiens"
+xref: Reactome:REACT_128 "Phosphorylation of Cdc25C at Ser216, Homo sapiens"
+xref: Reactome:REACT_132 "Phosphorylation of Cyclin D1 at T286 by glycogen synthase kinase-3 beta, Homo sapiens"
+xref: Reactome:REACT_1326 "Regulation of NUDC by phosphorylation, Homo sapiens"
+xref: Reactome:REACT_13431 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Homo sapiens"
+xref: Reactome:REACT_13581 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Oryctolagus cuniculus"
+xref: Reactome:REACT_1362 "Phosphorylation of the Scc1:Cohesion Complex, Homo sapiens"
+xref: Reactome:REACT_13817 "Autophosphorylation of PAK-2p34, Oryctolagus cuniculus"
+xref: Reactome:REACT_1382 "Phosphorylation of PDE3B by AKT-1, Mus musculus"
+xref: Reactome:REACT_13820 "Autophosphorylation of PAK-2p34 in the activation loop, Homo sapiens"
+xref: Reactome:REACT_1420 "SOS phosphorylation and dissociation (SHC), Homo sapiens"
+xref: Reactome:REACT_1481 "Phosphorylation of the SA2 Cohesin Complex, Homo sapiens"
+xref: Reactome:REACT_1517 "Phosphorylation of histone H2AX at Serine-139 by ATM at the site of DSB, Homo sapiens"
+xref: Reactome:REACT_15386 "Plk1-mediated phosphorylation of Nlp, Homo sapiens"
+xref: Reactome:REACT_1603 "Phosphorylation and activation of CHK2 by ATM, Homo sapiens"
+xref: Reactome:REACT_1657 "Phosphorylation of Cyclin E1:Cdk2 complexes by Myt1, Homo sapiens"
+xref: Reactome:REACT_1680 "Phosphorylation of Cdc25A at Ser-123 in response to DNA damage, Homo sapiens"
+xref: Reactome:REACT_169 "SOS phosphorylation and dissociation (IRS), Homo sapiens"
+xref: Reactome:REACT_1727 "RAF1 phosphorylates MEK2, Homo sapiens"
+xref: Reactome:REACT_1756 "Phosphorylation of p53 at ser-15 by ATM kinase, Homo sapiens"
+xref: Reactome:REACT_1782 "Phosphorylation of MDC1/NFBD1 by ATM (within 2 c-term BRCT domains), Homo sapiens"
+xref: Reactome:REACT_1808 "Activation of the Anaphase Promoting Complex (APC) by PLK1, Homo sapiens"
+xref: Reactome:REACT_1878 "Phosphorylation of PDE3B, Homo sapiens"
+xref: Reactome:REACT_188 "Akt1 phosphorylates BAD protein, Homo sapiens"
+xref: Reactome:REACT_1888 "Phosphorylation of DLC1 by MAPK 8, Homo sapiens"
+xref: Reactome:REACT_1930 "Regulation of KIF23 (MKLP1) by phosphorylation, Homo sapiens"
+xref: Reactome:REACT_19312 "Phosphorylation of PD-1, Homo sapiens"
+xref: Reactome:REACT_1944 "Inactivation of Wee1 kinase, Homo sapiens"
+xref: Reactome:REACT_1981 "Phosphorylation of DLC2 by MAPK-8, Homo sapiens"
+xref: Reactome:REACT_2009 "Phosphorylation of NBS1 by ATM, Homo sapiens"
+xref: Reactome:REACT_203 "Raf1 phosphorylates MEK1, Rattus norvegicus"
+xref: Reactome:REACT_20503 "Phosphorylation of CREB by ribosomal protein S6 kinase, Homo sapiens"
+xref: Reactome:REACT_20543 "Phosphorylation of COP1 at Ser-387 by ATM, Homo sapiens"
+xref: Reactome:REACT_20562 "Phosphorylation by MAPK/ERK, Homo sapiens"
+xref: Reactome:REACT_20578 "Raf activation, Homo sapiens"
+xref: Reactome:REACT_20583 "Phosphorylation of CREB by PKA, Homo sapiens"
+xref: Reactome:REACT_20631 "Activation of MAPK, Homo sapiens"
+xref: Reactome:REACT_20640 "Phophorylation by PDK1, Homo sapiens"
+xref: Reactome:REACT_2066 "Hyperphosphorylation (Ser2) of RNA Pol II CTD by P-TEFb complex, Homo sapiens"
+xref: Reactome:REACT_2111 "Orc1 is phosphorylated by cyclin A/CDK2, Homo sapiens"
+xref: Reactome:REACT_2119 "Activation of Cdc25C, Homo sapiens"
+xref: Reactome:REACT_215 "Autophosphorylation of DNA-PKcs, Homo sapiens"
+xref: Reactome:REACT_22099 "Phosphorylation of L1 by ERK, Homo sapiens"
+xref: Reactome:REACT_22378 "Phosphorylation of L1 by CK-II, Homo sapiens"
+xref: Reactome:REACT_23976 "Raf1 phosphorylates MEK2, Rattus norvegicus"
+xref: Reactome:REACT_23990 "Phosphorylation of cPLA2 by ERK-2, Homo sapiens"
+xref: Reactome:REACT_244 "PIP2 conversion to PIP3, Homo sapiens"
+xref: Reactome:REACT_26 "SOS phosphorylation and dissociation (IRS, Crk), Homo sapiens"
+xref: Reactome:REACT_264 "Phosphorylation of Wee1 kinase by Chk1, Homo sapiens"
+xref: Reactome:REACT_28054 "Phosphorylation of BRCA1 at multiple sites by ATM, Mus musculus"
+xref: Reactome:REACT_28091 "Inactivation of Wee1 kinase, Canis familiaris"
+xref: Reactome:REACT_28113 "RAF1 phosphorylates MEK1, Taeniopygia guttata"
+xref: Reactome:REACT_28163 "Phosphorylation of MDC1/NFBD1 by ATM (within 2 c-term BRCT domains), Canis familiaris"
+xref: Reactome:REACT_28264 "Phosphorylation of Wee1 kinase by Chk1, Arabidopsis thaliana"
+xref: Reactome:REACT_28480 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Danio rerio"
+xref: Reactome:REACT_28555 "Activation of the Anaphase Promoting Complex (APC) by PLK1, Xenopus tropicalis"
+xref: Reactome:REACT_28681 "Phosphorylation of Cyclin E:Cdk2 complexes by Wee-1, Rattus norvegicus"
+xref: Reactome:REACT_28719 "Phosphorylation and activation of eIF4B by activated S6K1, Xenopus tropicalis"
+xref: Reactome:REACT_28743 "RAF1 phosphorylates MEK2, Mus musculus"
+xref: Reactome:REACT_28746 "Phosphorylation of MDM2 at serine-395 by ATM kinase, Danio rerio"
+xref: Reactome:REACT_28824 "Down Regulation of Emi1 through Phosphorylation of Emi1, Danio rerio"
+xref: Reactome:REACT_29029 "Phosphorylation of L1 by ERK, Caenorhabditis elegans"
+xref: Reactome:REACT_29168 "Phosphorylation of Cyclin A:Cdk2 at Tyr 15, Canis familiaris"
+xref: Reactome:REACT_29201 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Saccharomyces cerevisiae"
+xref: Reactome:REACT_29213 "Activation of Cdc25C, Rattus norvegicus"
+xref: Reactome:REACT_29277 "CAK-mediated phosphorylation of Cyclin B1:Cdc2 complexes, Drosophila melanogaster"
+xref: Reactome:REACT_29284 "Phosphorylation of beta-catenin at Ser45 by CK1 alpha, Xenopus tropicalis"
+xref: Reactome:REACT_29289 "Activation of S6K1, Gallus gallus"
+xref: Reactome:REACT_29300 "Phosphorylation of L1 by ERK, Drosophila melanogaster"
+xref: Reactome:REACT_29334 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Rattus norvegicus"
+xref: Reactome:REACT_29395 "Phosphorylation of AKT2 by PDK1, Xenopus tropicalis"
+xref: Reactome:REACT_29396 "Orc1 is phosphorylated by cyclin A/CDK2, Canis familiaris"
+xref: Reactome:REACT_29410 "Regulation of KIF20A (MKL2) by phosphorylation, Rattus norvegicus"
+xref: Reactome:REACT_29451 "Phosphorylation of Cyclin D1 at T286 by glycogen synthase kinase-3 beta, Bos taurus"
+xref: Reactome:REACT_29588 "Phosphorylation of 4E-BP1 by activated mTORC1, Taeniopygia guttata"
+xref: Reactome:REACT_29614 "Regulation of NUDC by phosphorylation, Rattus norvegicus"
+xref: Reactome:REACT_29689 "Cdc6 protein is phosphorylated by CDK, Bos taurus"
+xref: Reactome:REACT_29694 "Phosphorylation of PDE3B, Canis familiaris"
+xref: Reactome:REACT_29759 "Hyperphosphorylation (Ser2) of RNA Pol II CTD by P-TEFb complex, Bos taurus"
+xref: Reactome:REACT_29788 "Wee1-mediated phosphorylation of Cyclin A:phospho-Cdc2 complexes, Xenopus tropicalis"
+xref: Reactome:REACT_29873 "Phosphorylation of APC component of the destruction complex, Taeniopygia guttata"
+xref: Reactome:REACT_29914 "Down Regulation of Emi1 through Phosphorylation of Emi1, Canis familiaris"
+xref: Reactome:REACT_30020 "Phosphorylation (Ser5) of RNA pol II CTD, Rattus norvegicus"
+xref: Reactome:REACT_30023 "Phosphorylation (Ser5) of RNA pol II CTD, Xenopus tropicalis"
+xref: Reactome:REACT_30052 "Phosphorylation of BRCA1 at multiple sites by ATM, Bos taurus"
+xref: Reactome:REACT_30070 "Phosphorylation of L1 by CK-II, Mus musculus"
+xref: Reactome:REACT_30084 "PIP2 conversion to PIP3, Canis familiaris"
+xref: Reactome:REACT_30113 "SOS phosphorylation and dissociation (IRS, Crk), Drosophila melanogaster"
+xref: Reactome:REACT_30116 "Phosphorylation and activation of eIF4B by activated S6K1, Canis familiaris"
+xref: Reactome:REACT_30165 "Phosphorylation of the Emi1 DSGxxS degron by Plk1, Gallus gallus"
+xref: Reactome:REACT_302 "Phosphorylation and activation of Chk1 by ATM, Homo sapiens"
+xref: Reactome:REACT_30230 "Phosphorylation of the SA2 Cohesin Complex, Caenorhabditis elegans"
+xref: Reactome:REACT_30345 "RAF1 phosphorylates MEK1, Gallus gallus"
+xref: Reactome:REACT_30490 "Inactivation of Myt1 kinase, Danio rerio"
+xref: Reactome:REACT_30496 "Phosphorylation of the Scc1:Cohesion Complex, Xenopus tropicalis"
+xref: Reactome:REACT_30679 "Phosphorylation and inactivation of eEF2K by activated S6K1, Mus musculus"
+xref: Reactome:REACT_30700 "Phosphorylation of BRCA1 at multiple sites by ATM, Gallus gallus"
+xref: Reactome:REACT_30836 "Inactivation of Myt1 kinase, Bos taurus"
+xref: Reactome:REACT_30921 "Phosphorylation and activation of Chk1 by ATM, Xenopus tropicalis"
+xref: Reactome:REACT_30938 "Hyperphosphorylation (Ser2) of RNA Pol II CTD by P-TEFb complex, Canis familiaris"
+xref: Reactome:REACT_30948 "PIP2 conversion to PIP3, Gallus gallus"
+xref: Reactome:REACT_30985 "Plk1-mediated phosphorylation of Nlp, Canis familiaris"
+xref: Reactome:REACT_30997 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Rattus norvegicus"
+xref: Reactome:REACT_31081 "Phosphorylation of TSC2 by PKB, Canis familiaris"
+xref: Reactome:REACT_31149 "Phosphorylation of the Scc1:Cohesion Complex, Danio rerio"
+xref: Reactome:REACT_31196 "Phosphorylation of histone H2AX at Serine-139 by ATM at the site of DSB, Canis familiaris"
+xref: Reactome:REACT_31227 "Regulation of KIF20A (MKL2) by phosphorylation, Gallus gallus"
+xref: Reactome:REACT_31273 "Phosphorylation of the Scc1:Cohesion Complex, Canis familiaris"
+xref: Reactome:REACT_31290 "Orc1 is phosphorylated by cyclin A/CDK2, Rattus norvegicus"
+xref: Reactome:REACT_31293 "Phosphorylation of Cdc25A at Ser-123 in response to DNA damage, Danio rerio"
+xref: Reactome:REACT_31449 "Phosphorylation and activation of CHK2 by ATM, Danio rerio"
+xref: Reactome:REACT_31466 "Activation of S6K1, Bos taurus"
+xref: Reactome:REACT_31519 "Phosphorylation of the SA2 Cohesin Complex, Danio rerio"
+xref: Reactome:REACT_31536 "Phosphorylation of NBS1 by ATM, Taeniopygia guttata"
+xref: Reactome:REACT_31571 "Autophosphorylation of PAK-2p34 in the activation loop, Gallus gallus"
+xref: Reactome:REACT_31625 "Phosphorylation of L1 by ERK, Taeniopygia guttata"
+xref: Reactome:REACT_31639 "SOS phosphorylation and dissociation (SHC), Rattus norvegicus"
+xref: Reactome:REACT_31868 "Phosphorylation and activation of CHK2 by ATM, Canis familiaris"
+xref: Reactome:REACT_31915 "Phosphorylation of L1 by CK-II, Drosophila melanogaster"
+xref: Reactome:REACT_31935 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Sus scrofa"
+xref: Reactome:REACT_31984 "Phosphorylation (Ser5) of RNA pol II CTD, Arabidopsis thaliana"
+xref: Reactome:REACT_32009 "Wee1- mediated phosphorylation of Cyclin B1:phospho-Cdc2 complexes, Mus musculus"
+xref: Reactome:REACT_32077 "Inactivation of Myt1 kinase, Dictyostelium discoideum"
+xref: Reactome:REACT_32079 "Phosphorylation of MDC1/NFBD1 by ATM (within 2 c-term BRCT domains), Danio rerio"
+xref: Reactome:REACT_32145 "Phosphorylation of COP1 at Ser-387 by ATM, Canis familiaris"
+xref: Reactome:REACT_32150 "Phosphorylation of NBS1 by ATM, Arabidopsis thaliana"
+xref: Reactome:REACT_32271 "Phosphorylation of cPLA2 by ERK-2, Taeniopygia guttata"
+xref: Reactome:REACT_32358 "Phosphorylation of MDM2 at serine-395 by ATM kinase, Canis familiaris"
+xref: Reactome:REACT_32374 "Mcm2-7 is phosphorylated by DDK, Canis familiaris"
+xref: Reactome:REACT_32438 "Phosphorylation of proteins involved in the G1/S transition by Cyclin A:Cdk2, Sus scrofa"
+xref: Reactome:REACT_32492 "Phosphorylation of BRCA1 at multiple sites by ATM, Rattus norvegicus"
+xref: Reactome:REACT_32565 "Phosphorylation of NBS1 by ATM, Gallus gallus"
+xref: Reactome:REACT_32598 "Phosphorylation and activation of eIF4B by activated S6K1, Taeniopygia guttata"
+xref: Reactome:REACT_32620 "Phosphorylation of the Emi1 DSGxxS degron by Plk1, Bos taurus"
+xref: Reactome:REACT_32845 "Phosphorylation of Cyclin D:Cdk4/6 complexes, Rattus norvegicus"
+xref: Reactome:REACT_32906 "Phosphorylation and inactivation of eEF2K by activated S6K1, Sus scrofa"
+xref: Reactome:REACT_32956 "Phosphorylation of phospho-(Ser45 ) at Thr 41 by GSK-3, Mus musculus"
+xref: Reactome:REACT_33003 "Phosphorylation of the SA2 Cohesin Complex, Dictyostelium discoideum"
+xref: Reactome:REACT_33009 "Phosphorylation of L1 by ERK, Danio rerio"
+xref: Reactome:REACT_33080 "Phosphorylation of histone H2AX at Serine-139 by ATM at the site of DSB, Taeniopygia guttata"
+xref: Reactome:REACT_33369 "Phosphorylation of NBS1 by ATM, Rattus norvegicus"
+xref: Reactome:REACT_33385 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Canis familiaris"
+xref: Reactome:REACT_33519 "Phosphorylation of the Emi1 DSGxxS degron by Plk1, Mus musculus"
+xref: Reactome:REACT_33532 "Phosphorylation of complexed TSC2 by PKB, Bos taurus"
+xref: Reactome:REACT_33692 "Phosphorylation of BRCA1 at multiple sites by ATM, Taeniopygia guttata"
+xref: Reactome:REACT_33840 "Regulation of KIF23 (MKLP1) by phosphorylation, Schizosaccharomyces pombe"
+xref: Reactome:REACT_33928 "Phosphorylation of Cyclin D1 at T286 by glycogen synthase kinase-3 beta, Sus scrofa"
+xref: Reactome:REACT_33979 "Phosphorylation of the Emi1 DSGxxS degron by Plk1, Rattus norvegicus"
+xref: Reactome:REACT_34080 "Phosphorylation of PD-1, Mus musculus"
+xref: Reactome:REACT_34111 "Phosphorylation of Cdc25A at Ser-123 by Chk1, Canis familiaris"
+xref: Reactome:REACT_34145 "Phosphorylation of cPLA2 by ERK-2, Xenopus tropicalis"
+xref: Reactome:REACT_34222 "Phosphorylation of L1 by ERK, Rattus norvegicus"
+xref: Reactome:REACT_34285 "Activation of Cdc25C, Bos taurus"
+xref: Reactome:REACT_34310 "Phosphorylation and activation of Chk1 by ATM, Bos taurus"
+xref: Reactome:REACT_34403 "Phosphorylation (Ser5) of RNA pol II CTD, Danio rerio"
+xref: Reactome:REACT_34514 "Phosphorylation and inactivation of eEF2K by activated S6K1, Danio rerio"
+xref: Reactome:REACT_34516 "Cdc6 protein is phosphorylated by CDK, Canis familiaris"
+xref: Reactome:REACT_34607 "Phosphorylation of 4E-BP1 by activated mTORC1, Bos taurus"
+xref: Reactome:REACT_34741 "Phosphorylation of MDC1/NFBD1 by ATM (within 2 c-term BRCT domains), Rattus norvegicus"
+xref: Reactome:REACT_34788 "Phosphorylation and inactivation of eEF2K by activated S6K1, Xenopus tropicalis"
+xref: Reactome:REACT_34804 "Phosphoryation of phospho- (Ser45, Thr41) beta-catenin at Ser37 by GSK-3, Gallus gallus"
+xref: Reactome:REACT_384 "Phosphorylation of Cyclin E2:Cdk2 complexes by Myt1, Homo sapiens"
+xref: Reactome:REACT_414 "Inactivation of Myt1 kinase, Homo sapiens"
+xref: Reactome:REACT_41715 "Hyperphosphorylation (Ser2) of RNA Pol II CTD by P-TEFb complex, Mus musculus"
+xref: Reactome:REACT_43 "Phosphorylation of Cdc25A at Ser-123 by Chk2, Homo sapiens"
+xref: Reactome:REACT_496 "Down Regulation of Emi1 through Phosphorylation of Emi1, Homo sapiens"
+xref: Reactome:REACT_54449 "Phosphorylation and activation of eIF4G by activated S6K1, Mus musculus"
+xref: Reactome:REACT_545 "RAF1 phosphorylates MEK1, Homo sapiens"
+xref: Reactome:REACT_559 "Phosphorylation and activation of Chk1 by ATM kinase, Mus musculus"
+xref: Reactome:REACT_58131 "PIP2 conversion to PIP3, Mus musculus"
+xref: Reactome:REACT_6139 "CAK-mediated phosphorylation of Cyclin A:Cdc2 complexes, Homo sapiens"
+xref: Reactome:REACT_6170 "Hyperphosphorylation (Ser2) of RNA Pol II CTD by the P-TEFb(Cyclin T1:Cdk9) complex, Homo sapiens"
+xref: Reactome:REACT_6178 "Wee1- mediated phosphorylation of Cyclin B1:phospho-Cdc2 complexes, Homo sapiens"
+xref: Reactome:REACT_6234 "Phosphorylation (Ser5) of RNA pol II CTD, Homo sapiens"
+xref: Reactome:REACT_6297 "Hyperphosphorylation (Ser2) of RNA Pol II CTD by P-TEFb complex, Homo sapiens"
+xref: Reactome:REACT_6311 "Phosphorylation of NEFL by the P-TEFb(Cyclin T1:Cdk9) complex, Homo sapiens"
+xref: Reactome:REACT_6314 "CAK-mediated phosphorylation of Cyclin B1:Cdc2 complexes, Homo sapiens"
+xref: Reactome:REACT_6316 "Phosphorylation of DSIF by the P-TEFb(Cyclin T1:Cdk9) complex, Human immunodeficiency virus 1"
+xref: Reactome:REACT_6327 "Wee1-mediated phosphorylation of Cyclin A:phospho-Cdc2 complexes, Homo sapiens"
+xref: Reactome:REACT_6342 "Myt-1 mediated phosphorylation of Cyclin A:Cdc2, Homo sapiens"
+xref: Reactome:REACT_6353 "Phosphorylation of Cyclin B1 in the CRS domain, Homo sapiens"
+xref: Reactome:REACT_6725 "Phosphorylation of TSC2 by PKB, Homo sapiens"
+xref: Reactome:REACT_6778 "Phosphorylation and activation of eIF4B by activated S6K1, Homo sapiens"
+xref: Reactome:REACT_6859 "Free APC/C phosphorylated by Plk1, Homo sapiens"
+xref: Reactome:REACT_6861 "Phosphorylation of the Emi1 DSGxxS degron by Plk1, Homo sapiens"
+xref: Reactome:REACT_6870 "Phosphorylation and activation of eIF4G by activated S6K1, Homo sapiens"
+xref: Reactome:REACT_6873 "Phosphorylation of 4E-BP1 by activated mTORC1, Homo sapiens"
+xref: Reactome:REACT_6883 "Phosphorylation and inactivation of eEF2K by activated S6K1, Homo sapiens"
+xref: Reactome:REACT_6912 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Homo sapiens"
+xref: Reactome:REACT_6948 "Activation of S6K1, Homo sapiens"
+xref: Reactome:REACT_6952 "Phosphorylation of complexed TSC2 by PKB, Homo sapiens"
+xref: Reactome:REACT_76979 "Phosphorylation of Cyclin D:Cdk4/6 complexes, Danio rerio"
+xref: Reactome:REACT_77040 "Phosphorylation of COP1 at Ser-387 by ATM, Oryza sativa"
+xref: Reactome:REACT_77074 "Phosphorylation of MDM2 at serine-395 by ATM kinase, Mus musculus"
+xref: Reactome:REACT_77179 "Phosphorylation of Cdc25A at Ser-123 by Chk2, Bos taurus"
+xref: Reactome:REACT_77231 "Phosphorylation of DLC2 by MAPK-8, Gallus gallus"
+xref: Reactome:REACT_77234 "Plk1-mediated phosphorylation of Nlp, Gallus gallus"
+xref: Reactome:REACT_773 "Phosphorylation of Cyclin E:Cdk2 complexes by Wee-1, Homo sapiens"
+xref: Reactome:REACT_77326 "RAF1 phosphorylates MEK2, Taeniopygia guttata"
+xref: Reactome:REACT_77362 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Rattus norvegicus"
+xref: Reactome:REACT_77365 "Phosphorylation of the Emi1 DSGxxS degron by Plk1, Xenopus tropicalis"
+xref: Reactome:REACT_77397 "Phosphorylation of Cdc25A at Ser-123 in response to DNA damage, Mus musculus"
+xref: Reactome:REACT_77407 "Regulation of NUDC by phosphorylation, Bos taurus"
+xref: Reactome:REACT_77443 "Activation of the Anaphase Promoting Complex (APC) by PLK1, Danio rerio"
+xref: Reactome:REACT_77450 "Phosphorylation of L1 by CK-II, Sus scrofa"
+xref: Reactome:REACT_77535 "Phosphorylation of Cyclin D:Cdk4/6 complexes, Mus musculus"
+xref: Reactome:REACT_77550 "CAK-mediated phosphorylation of Cyclin A:Cdc2 complexes, Drosophila melanogaster"
+xref: Reactome:REACT_77566 "CAK-mediated phosphorylation of Cyclin A:Cdc2 complexes, Gallus gallus"
+xref: Reactome:REACT_77606 "Phosphoryation of phospho- (Ser45, Thr41) beta-catenin at Ser37 by GSK-3, Canis familiaris"
+xref: Reactome:REACT_77615 "Phosphorylation of phospho-(Ser45,Thr41,Ser37) at Ser33 by GSK-3, Gallus gallus"
+xref: Reactome:REACT_77654 "CAK-mediated phosphorylation of Cyclin A:Cdk2, Drosophila melanogaster"
+xref: Reactome:REACT_77660 "Regulation of KIF23 (MKLP1) by phosphorylation, Caenorhabditis elegans"
+xref: Reactome:REACT_77733 "Phosphorylation of PDE3B, Danio rerio"
+xref: Reactome:REACT_77834 "Activation of the Anaphase Promoting Complex (APC) by PLK1, Rattus norvegicus"
+xref: Reactome:REACT_77857 "Phosphorylation (Ser5) of RNA pol II CTD, Drosophila melanogaster"
+xref: Reactome:REACT_77897 "Phosphorylation of Wee1 kinase by Chk1, Taeniopygia guttata"
+xref: Reactome:REACT_77911 "Mcm2-7 is phosphorylated by DDK, Taeniopygia guttata"
+xref: Reactome:REACT_77928 "Autophosphorylation of PAK-2p34 in the activation loop, Sus scrofa"
+xref: Reactome:REACT_77949 "Phosphorylation of Wee1 kinase by Chk1, Drosophila melanogaster"
+xref: Reactome:REACT_77977 "Phosphorylation of Cyclin B1 in the CRS domain, Bos taurus"
+xref: Reactome:REACT_78014 "Plk1-mediated phosphorylation of Nlp, Taeniopygia guttata"
+xref: Reactome:REACT_78035 "Phosphorylation of phospho-(Ser45 ) at Thr 41 by GSK-3, Taeniopygia guttata"
+xref: Reactome:REACT_78087 "Phosphorylation of TSC2 by PKB, Xenopus tropicalis"
+xref: Reactome:REACT_78121 "Phosphorylation of Cdc25A at Ser-123 by Chk2, Gallus gallus"
+xref: Reactome:REACT_78226 "Regulation of NUDC by phosphorylation, Xenopus tropicalis"
+xref: Reactome:REACT_78281 "Phosphoryation of phospho- (Ser45, Thr41) beta-catenin at Ser37 by GSK-3, Rattus norvegicus"
+xref: Reactome:REACT_78427 "Myt-1 mediated phosphorylation of Cyclin A:Cdc2, Danio rerio"
+xref: Reactome:REACT_78450 "Phosphorylation and activation of eIF4B by activated S6K1, Drosophila melanogaster"
+xref: Reactome:REACT_78451 "CAK-mediated phosphorylation of Cyclin A:Cdc2 complexes, Taeniopygia guttata"
+xref: Reactome:REACT_78503 "Phosphorylation of histone H2AX at Serine-139 by ATM at the site of DSB, Bos taurus"
+xref: Reactome:REACT_78533 "Wee1-mediated phosphorylation of Cyclin A:phospho-Cdc2 complexes, Danio rerio"
+xref: Reactome:REACT_78539 "Down Regulation of Emi1 through Phosphorylation of Emi1, Xenopus tropicalis"
+xref: Reactome:REACT_78556 "Free APC/C phosphorylated by Plk1, Drosophila melanogaster"
+xref: Reactome:REACT_78625 "Phosphorylation and inactivation of eEF2K by activated S6K1, Caenorhabditis elegans"
+xref: Reactome:REACT_78651 "CAK-mediated phosphorylation of Cyclin B1:Cdc2 complexes, Rattus norvegicus"
+xref: Reactome:REACT_78696 "Phosphorylation of phospho-(Ser45 ) at Thr 41 by GSK-3, Xenopus tropicalis"
+xref: Reactome:REACT_78748 "Cdc6 protein is phosphorylated by CDK, Drosophila melanogaster"
+xref: Reactome:REACT_78901 "Phosphorylation (Ser5) of RNA pol II CTD, Mus musculus"
+xref: Reactome:REACT_79012 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Schizosaccharomyces pombe"
+xref: Reactome:REACT_79039 "Autophosphorylation of PAK-2p34 in the activation loop, Caenorhabditis elegans"
+xref: Reactome:REACT_79087 "Phosphorylation of Wee1 kinase by Chk1, Oryza sativa"
+xref: Reactome:REACT_79125 "SOS phosphorylation and dissociation (IRS), Bos taurus"
+xref: Reactome:REACT_79182 "Phosphorylation of Cyclin B1 in the CRS domain, Canis familiaris"
+xref: Reactome:REACT_79208 "Mcm2-7 is phosphorylated by DDK, Bos taurus"
+xref: Reactome:REACT_79220 "Phosphorylation of 4E-BP1 by activated mTORC1, Canis familiaris"
+xref: Reactome:REACT_79255 "Phosphorylation of p53 at ser-15 by ATM kinase, Danio rerio"
+xref: Reactome:REACT_79372 "Cdc6 protein is phosphorylated by CDK, Danio rerio"
+xref: Reactome:REACT_79573 "Phosphorylation of p53 at ser-15 by ATM kinase, Mus musculus"
+xref: Reactome:REACT_79686 "Phosphorylation of the Scc1:Cohesion Complex, Drosophila melanogaster"
+xref: Reactome:REACT_79694 "Autophosphorylation of PAK-2p34 in the activation loop, Xenopus tropicalis"
+xref: Reactome:REACT_79700 "Activation of S6K1, Taeniopygia guttata"
+xref: Reactome:REACT_79709 "Orc1 is phosphorylated by cyclin A/CDK2, Mus musculus"
+xref: Reactome:REACT_79720 "Phosphorylation of Cyclin E2:Cdk2 complexes by Myt1, Danio rerio"
+xref: Reactome:REACT_80110 "Phosphorylation of proteins involved in the G1/S transition by Cyclin A:Cdk2, Drosophila melanogaster"
+xref: Reactome:REACT_80144 "Phosphorylation of complexed TSC2 by PKB, Sus scrofa"
+xref: Reactome:REACT_80185 "Phosphorylation of Cyclin E1:Cdk2 complexes by Myt1, Mus musculus"
+xref: Reactome:REACT_80213 "Activation of S6K1, Canis familiaris"
+xref: Reactome:REACT_80218 "Phosphorylation of the Scc1:Cohesion Complex, Dictyostelium discoideum"
+xref: Reactome:REACT_80239 "Regulation of KIF20A (MKL2) by phosphorylation, Dictyostelium discoideum"
+xref: Reactome:REACT_80255 "Mcm2-7 is phosphorylated by DDK, Mus musculus"
+xref: Reactome:REACT_80591 "Regulation of KIF20A (MKL2) by phosphorylation, Drosophila melanogaster"
+xref: Reactome:REACT_80606 "Phosphorylation of NBS1 by ATM, Oryza sativa"
+xref: Reactome:REACT_80617 "Inactivation of Wee1 kinase, Xenopus tropicalis"
+xref: Reactome:REACT_80632 "Phosphorylation of L1 by ERK, Schizosaccharomyces pombe"
+xref: Reactome:REACT_80665 "Down Regulation of Emi1 through Phosphorylation of Emi1, Taeniopygia guttata"
+xref: Reactome:REACT_80684 "Phosphorylation of COP1 at Ser-387 by ATM, Arabidopsis thaliana"
+xref: Reactome:REACT_80689 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Oryza sativa"
+xref: Reactome:REACT_80699 "PIP2 conversion to PIP3, Danio rerio"
+xref: Reactome:REACT_80700 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Sus scrofa"
+xref: Reactome:REACT_80714 "CAK-mediated phosphorylation of Cyclin A:Cdc2 complexes, Rattus norvegicus"
+xref: Reactome:REACT_80804 "Phosphorylation of PDE3B, Bos taurus"
+xref: Reactome:REACT_80853 "Phosphorylation (Ser5) of RNA pol II CTD, Dictyostelium discoideum"
+xref: Reactome:REACT_80860 "Phosphorylation of MDM2 at serine-395 by ATM kinase, Rattus norvegicus"
+xref: Reactome:REACT_80909 "Phosphorylation of Cdc25A at Ser-123 by Chk1, Drosophila melanogaster"
+xref: Reactome:REACT_81027 "PIP2 conversion to PIP3, Sus scrofa"
+xref: Reactome:REACT_81148 "Phosphorylation and activation of CHK2 by ATM, Taeniopygia guttata"
+xref: Reactome:REACT_81218 "Phosphorylation and activation of CHK2 by ATM, Rattus norvegicus"
+xref: Reactome:REACT_81439 "Phosphorylation of APC component of the destruction complex, Xenopus tropicalis"
+xref: Reactome:REACT_81458 "Phosphorylation of phospho-(Ser45 ) at Thr 41 by GSK-3, Bos taurus"
+xref: Reactome:REACT_81490 "Phosphorylation of phospho-(Ser45,Thr41,Ser37) at Ser33 by GSK-3, Xenopus tropicalis"
+xref: Reactome:REACT_81590 "Wee1- mediated phosphorylation of Cyclin B1:phospho-Cdc2 complexes, Bos taurus"
+xref: Reactome:REACT_81616 "Phosphorylation of Cyclin E2:Cdk2 complexes by Myt1, Canis familiaris"
+xref: Reactome:REACT_81647 "Phosphorylation of Cyclin E1:Cdk2 complexes by Myt1, Rattus norvegicus"
+xref: Reactome:REACT_81652 "Phosphorylation of Cdc25A at Ser-123 by Chk1, Rattus norvegicus"
+xref: Reactome:REACT_81693 "Phosphorylation of beta-catenin at Ser45 by CK1 alpha, Drosophila melanogaster"
+xref: Reactome:REACT_81715 "Orc1 is phosphorylated by cyclin A/CDK2, Drosophila melanogaster"
+xref: Reactome:REACT_81727 "Phosphorylation of Cyclin A:Cdk2 at Tyr 15, Danio rerio"
+xref: Reactome:REACT_81864 "Phosphorylation of Cx43 by c-src, Bos taurus"
+xref: Reactome:REACT_81941 "Phosphorylation of Cdc25A at Ser-123 by Chk1, Bos taurus"
+xref: Reactome:REACT_82037 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Mus musculus"
+xref: Reactome:REACT_82115 "Phosphorylation and activation of Chk1 by ATM, Saccharomyces cerevisiae"
+xref: Reactome:REACT_82125 "Phosphorylation of complexed TSC2 by PKB, Danio rerio"
+xref: Reactome:REACT_82128 "PIP2 conversion to PIP3, Taeniopygia guttata"
+xref: Reactome:REACT_82261 "Phosphorylation of DLC2 by MAPK-8, Xenopus tropicalis"
+xref: Reactome:REACT_82270 "Autophosphorylation of PAK-2p34 in the activation loop, Rattus norvegicus"
+xref: Reactome:REACT_82303 "Phosphorylation of Cyclin D:Cdk4/6 complexes, Xenopus tropicalis"
+xref: Reactome:REACT_82310 "Phosphorylation and activation of Chk1 by ATM, Gallus gallus"
+xref: Reactome:REACT_82361 "CAK-mediated phosphorylation of Cyclin B1:Cdc2 complexes, Canis familiaris"
+xref: Reactome:REACT_82456 "Phosphorylation of Cdc25A at Ser-123 in response to DNA damage, Bos taurus"
+xref: Reactome:REACT_82473 "Phosphorylation of the SA2 Cohesin Complex, Canis familiaris"
+xref: Reactome:REACT_82616 "Phosphorylation of phospho-(Ser45,Thr41,Ser37) at Ser33 by GSK-3, Mus musculus"
+xref: Reactome:REACT_82678 "Phosphorylation of complexed TSC2 by PKB, Rattus norvegicus"
+xref: Reactome:REACT_82728 "Plk1-mediated phosphorylation of Nlp, Mus musculus"
+xref: Reactome:REACT_82751 "Down Regulation of Emi1 through Phosphorylation of Emi1, Rattus norvegicus"
+xref: Reactome:REACT_82824 "Inactivation of Wee1 kinase, Rattus norvegicus"
+xref: Reactome:REACT_82901 "Phosphorylation of DLC2 by MAPK-8, Canis familiaris"
+xref: Reactome:REACT_82927 "PIP2 conversion to PIP3, Rattus norvegicus"
+xref: Reactome:REACT_83006 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Caenorhabditis elegans"
+xref: Reactome:REACT_83089 "Inactivation of Myt1 kinase, Saccharomyces cerevisiae"
+xref: Reactome:REACT_83110 "Phosphorylation (Ser5) of RNA pol II CTD, Schizosaccharomyces pombe"
+xref: Reactome:REACT_83178 "Phosphorylation and activation of Chk1 by ATM, Oryza sativa"
+xref: Reactome:REACT_83187 "Phosphorylation of the SA2 Cohesin Complex, Mus musculus"
+xref: Reactome:REACT_83239 "Phosphorylation and activation of eIF4G by activated S6K1, Gallus gallus"
+xref: Reactome:REACT_83279 "Phosphorylation of NBS1 by ATM, Canis familiaris"
+xref: Reactome:REACT_83297 "CAK-mediated phosphorylation of Cyclin A:Cdk2, Danio rerio"
+xref: Reactome:REACT_83436 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Arabidopsis thaliana"
+xref: Reactome:REACT_83476 "Phosphorylation and activation of CHK2 by ATM, Mus musculus"
+xref: Reactome:REACT_83529 "Wee1- mediated phosphorylation of Cyclin B1:phospho-Cdc2 complexes, Drosophila melanogaster"
+xref: Reactome:REACT_83533 "Phosphorylation and activation of Chk1 by ATM, Rattus norvegicus"
+xref: Reactome:REACT_83579 "Phosphorylation of Wee1 kinase by Chk1, Gallus gallus"
+xref: Reactome:REACT_83582 "Plk1-mediated phosphorylation of Nlp, Danio rerio"
+xref: Reactome:REACT_83671 "Wee1-mediated phosphorylation of Cyclin A:phospho-Cdc2 complexes, Taeniopygia guttata"
+xref: Reactome:REACT_83696 "Free APC/C phosphorylated by Plk1, Bos taurus"
+xref: Reactome:REACT_83709 "Phosphorylation of Cdc25A at Ser-123 by Chk1, Mus musculus"
+xref: Reactome:REACT_83727 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Gallus gallus"
+xref: Reactome:REACT_83899 "Phosphorylation of MDC1/NFBD1 by ATM (within 2 c-term BRCT domains), Sus scrofa"
+xref: Reactome:REACT_83979 "Phosphorylation of COP1 at Ser-387 by ATM, Mus musculus"
+xref: Reactome:REACT_84080 "Phosphorylation of the SA2 Cohesin Complex, Xenopus tropicalis"
+xref: Reactome:REACT_84082 "Phosphorylation of Wee1 kinase by Chk1, Rattus norvegicus"
+xref: Reactome:REACT_84208 "CAK-mediated phosphorylation of Cyclin B1:Cdc2 complexes, Mus musculus"
+xref: Reactome:REACT_84273 "Phosphorylation of L1 by ERK, Sus scrofa"
+xref: Reactome:REACT_84348 "Phosphorylation of COP1 at Ser-387 by ATM, Taeniopygia guttata"
+xref: Reactome:REACT_84405 "Phosphorylation of p53 at ser-15 by ATM kinase, Rattus norvegicus"
+xref: Reactome:REACT_845 "Phosphorylation of Cdc25A at Ser-123 by Chk1, Homo sapiens"
+xref: Reactome:REACT_84560 "Cdc6 protein is phosphorylated by CDK, Saccharomyces cerevisiae"
+xref: Reactome:REACT_84656 "Phosphoryation of phospho- (Ser45, Thr41) beta-catenin at Ser37 by GSK-3, Bos taurus"
+xref: Reactome:REACT_84932 "Phosphorylation of Wee1 kinase by Chk1, Sus scrofa"
+xref: Reactome:REACT_85009 "Phosphorylation of beta-catenin at Ser45 by CK1 alpha, Taeniopygia guttata"
+xref: Reactome:REACT_85017 "Activation of S6K1, Dictyostelium discoideum"
+xref: Reactome:REACT_85044 "Phosphorylation of Cyclin E1:Cdk2 complexes by Myt1, Canis familiaris"
+xref: Reactome:REACT_85066 "Activation of the Anaphase Promoting Complex (APC) by PLK1, Taeniopygia guttata"
+xref: Reactome:REACT_85256 "Phosphorylation of Cdc25C at Ser216, Mus musculus"
+xref: Reactome:REACT_85328 "Regulation of KIF20A (MKL2) by phosphorylation, Mus musculus"
+xref: Reactome:REACT_85379 "Phosphorylation of Cx43 by c-src, Sus scrofa"
+xref: Reactome:REACT_85449 "Phosphorylation and activation of eIF4G by activated S6K1, Bos taurus"
+xref: Reactome:REACT_85586 "Wee1-mediated phosphorylation of Cyclin A:phospho-Cdc2 complexes, Gallus gallus"
+xref: Reactome:REACT_85699 "Phosphorylation of Cyclin B1 in the CRS domain, Rattus norvegicus"
+xref: Reactome:REACT_85720 "Phosphorylation of L1 by ERK, Canis familiaris"
+xref: Reactome:REACT_85745 "CAK-mediated phosphorylation of Cyclin B1:Cdc2 complexes, Xenopus tropicalis"
+xref: Reactome:REACT_85751 "Phosphorylation of BRCA1 at multiple sites by ATM, Canis familiaris"
+xref: Reactome:REACT_85812 "Phosphorylation and activation of Chk1 by ATM, Drosophila melanogaster"
+xref: Reactome:REACT_85836 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Gallus gallus"
+xref: Reactome:REACT_85871 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Mus musculus"
+xref: Reactome:REACT_86014 "Phosphorylation of the SA2 Cohesin Complex, Bos taurus"
+xref: Reactome:REACT_86033 "Phosphorylation and activation of CHK2 by ATM, Schizosaccharomyces pombe"
+xref: Reactome:REACT_86061 "Phosphorylation of Cyclin E1:Cdk2 complexes by Myt1, Bos taurus"
+xref: Reactome:REACT_86092 "Phosphorylation of COP1 at Ser-387 by ATM, Bos taurus"
+xref: Reactome:REACT_86211 "Activation of the Anaphase Promoting Complex (APC) by PLK1, Saccharomyces cerevisiae"
+xref: Reactome:REACT_86252 "Phosphorylation of Cyclin A:Cdk2 at Tyr 15, Drosophila melanogaster"
+xref: Reactome:REACT_86261 "Regulation of NUDC by phosphorylation, Dictyostelium discoideum"
+xref: Reactome:REACT_86277 "Phosphorylation of TSC2 by PKB, Bos taurus"
+xref: Reactome:REACT_86365 "Phosphorylation and activation of eIF4G by activated S6K1, Rattus norvegicus"
+xref: Reactome:REACT_86372 "Akt1 phosphorylates BAD protein, Mus musculus"
+xref: Reactome:REACT_86415 "Phosphorylation of Cx43 by c-src, Xenopus tropicalis"
+xref: Reactome:REACT_86422 "Phosphorylation of PD-1, Rattus norvegicus"
+xref: Reactome:REACT_86533 "Cdc6 protein is phosphorylated by CDK, Sus scrofa"
+xref: Reactome:REACT_86736 "Phosphorylation of proteins involved in the G1/S transition by Cyclin A:Cdk2, Rattus norvegicus"
+xref: Reactome:REACT_86800 "Phosphorylation of Cyclin D1 at T286 by glycogen synthase kinase-3 beta, Danio rerio"
+xref: Reactome:REACT_86867 "Phosphorylation of p53 at ser-15 by ATM kinase, Bos taurus"
+xref: Reactome:REACT_86952 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Sus scrofa"
+xref: Reactome:REACT_86967 "Phosphorylation (Ser5) of RNA pol II CTD, Gallus gallus"
+xref: Reactome:REACT_87010 "Regulation of NUDC by phosphorylation, Danio rerio"
+xref: Reactome:REACT_87121 "Phosphorylation of cPLA2 by ERK-2, Bos taurus"
+xref: Reactome:REACT_87149 "Phosphorylation of L1 by CK-II, Danio rerio"
+xref: Reactome:REACT_87212 "Phosphorylation of Cx43 by c-src, Mus musculus"
+xref: Reactome:REACT_87222 "Cdc6 protein is phosphorylated by CDK, Schizosaccharomyces pombe"
+xref: Reactome:REACT_87298 "Phosphorylation of Cyclin A:Cdk2 at Tyr 15, Sus scrofa"
+xref: Reactome:REACT_87329 "Regulation of KIF23 (MKLP1) by phosphorylation, Mus musculus"
+xref: Reactome:REACT_87391 "Phosphorylation of Cx43 by c-src, Rattus norvegicus"
+xref: Reactome:REACT_87424 "SOS phosphorylation and dissociation (SHC), Danio rerio"
+xref: Reactome:REACT_87437 "Phosphorylation of AKT2 by PDK1, Caenorhabditis elegans"
+xref: Reactome:REACT_87485 "Activation of S6K1, Xenopus tropicalis"
+xref: Reactome:REACT_87497 "Akt1 phosphorylates BAD protein, Bos taurus"
+xref: Reactome:REACT_87503 "Phosphorylation of Cyclin E2:Cdk2 complexes by Myt1, Xenopus tropicalis"
+xref: Reactome:REACT_87523 "Phosphorylation of Cyclin B1 in the CRS domain, Mus musculus"
+xref: Reactome:REACT_87534 "Phosphorylation of MDM2 at serine-395 by ATM kinase, Gallus gallus"
+xref: Reactome:REACT_87593 "Activation of the Anaphase Promoting Complex (APC) by PLK1, Gallus gallus"
+xref: Reactome:REACT_87650 "Phosphorylation of proteins involved in the G1/S transition by Cyclin A:Cdk2, Xenopus tropicalis"
+xref: Reactome:REACT_87679 "Phosphorylation of PDE3B, Xenopus tropicalis"
+xref: Reactome:REACT_87753 "Wee1-mediated phosphorylation of Cyclin A:phospho-Cdc2 complexes, Bos taurus"
+xref: Reactome:REACT_87880 "CAK-mediated phosphorylation of Cyclin B1:Cdc2 complexes, Danio rerio"
+xref: Reactome:REACT_87967 "Hyperphosphorylation (Ser2) of RNA Pol II CTD by P-TEFb complex, Xenopus tropicalis"
+xref: Reactome:REACT_88025 "Activation of S6K1, Mus musculus"
+xref: Reactome:REACT_88055 "Phosphorylation of NBS1 by ATM, Sus scrofa"
+xref: Reactome:REACT_88091 "Phosphorylation of Cdc25A at Ser-123 by Chk1, Xenopus tropicalis"
+xref: Reactome:REACT_88220 "Regulation of KIF23 (MKLP1) by phosphorylation, Rattus norvegicus"
+xref: Reactome:REACT_88298 "Phosphorylation of Cdc25A at Ser-123 by Chk1, Taeniopygia guttata"
+xref: Reactome:REACT_88326 "CAK-mediated phosphorylation of Cyclin A:Cdk2, Canis familiaris"
+xref: Reactome:REACT_88374 "CAK-mediated phosphorylation of Cyclin A:Cdk2, Xenopus tropicalis"
+xref: Reactome:REACT_88421 "Phosphorylation and inactivation of eEF2K by activated S6K1, Rattus norvegicus"
+xref: Reactome:REACT_88430 "Orc1 is phosphorylated by cyclin A/CDK2, Bos taurus"
+xref: Reactome:REACT_88440 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Caenorhabditis elegans"
+xref: Reactome:REACT_88458 "Phosphorylation of cPLA2 by ERK-2, Danio rerio"
+xref: Reactome:REACT_88486 "Inactivation of Wee1 kinase, Taeniopygia guttata"
+xref: Reactome:REACT_88516 "Cdc6 protein is phosphorylated by CDK, Rattus norvegicus"
+xref: Reactome:REACT_88548 "Phosphorylation of the Emi1 DSGxxS degron by Plk1, Taeniopygia guttata"
+xref: Reactome:REACT_88564 "Plk1-mediated phosphorylation of Nlp, Xenopus tropicalis"
+xref: Reactome:REACT_88590 "Phosphorylation of Cdc25A at Ser-123 by Chk2, Rattus norvegicus"
+xref: Reactome:REACT_88665 "Phosphorylation of Cdc25A at Ser-123 by Chk2, Danio rerio"
+xref: Reactome:REACT_88668 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Drosophila melanogaster"
+xref: Reactome:REACT_88766 "Phosphorylation (Ser5) of RNA pol II CTD, Oryza sativa"
+xref: Reactome:REACT_88871 "Hyperphosphorylation (Ser2) of RNA Pol II CTD by P-TEFb complex, Rattus norvegicus"
+xref: Reactome:REACT_88928 "Autophosphorylation of PAK-2p34 in the activation loop, Drosophila melanogaster"
+xref: Reactome:REACT_88987 "Free APC/C phosphorylated by Plk1, Canis familiaris"
+xref: Reactome:REACT_89001 "Phosphorylation of Cdc25A at Ser-123 by Chk1, Gallus gallus"
+xref: Reactome:REACT_89026 "Phosphorylation of PD-1, Gallus gallus"
+xref: Reactome:REACT_89122 "Activation of Cdc25C, Canis familiaris"
+xref: Reactome:REACT_89366 "Phosphorylation of APC component of the destruction complex, Canis familiaris"
+xref: Reactome:REACT_89427 "Phosphorylation of AKT2 by PDK1, Bos taurus"
+xref: Reactome:REACT_89464 "Phosphorylation of phospho-(Ser45,Thr41,Ser37) at Ser33 by GSK-3, Taeniopygia guttata"
+xref: Reactome:REACT_89547 "Phosphorylation of NBS1 by ATM, Xenopus tropicalis"
+xref: Reactome:REACT_89579 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Xenopus tropicalis"
+xref: Reactome:REACT_89769 "Phosphorylation of MDM2 at serine-395 by ATM kinase, Taeniopygia guttata"
+xref: Reactome:REACT_89794 "Phosphorylation of beta-catenin at Ser45 by CK1 alpha, Mus musculus"
+xref: Reactome:REACT_89879 "Phosphoryation of phospho- (Ser45, Thr41) beta-catenin at Ser37 by GSK-3, Mus musculus"
+xref: Reactome:REACT_89988 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Schizosaccharomyces pombe"
+xref: Reactome:REACT_9007 "Phosphorylation of proteins involved in the G1/S transition by Cyclin A:Cdk2, Homo sapiens"
+xref: Reactome:REACT_90132 "Phosphorylation of AKT2 by PDK1, Sus scrofa"
+xref: Reactome:REACT_90167 "Phosphorylation of Wee1 kinase by Chk1, Bos taurus"
+xref: Reactome:REACT_90220 "Wee1- mediated phosphorylation of Cyclin B1:phospho-Cdc2 complexes, Rattus norvegicus"
+xref: Reactome:REACT_90227 "Phosphorylation of AKT2 by PDK1, Mus musculus"
+xref: Reactome:REACT_90290 "Phosphorylation of Cdc25A at Ser-123 in response to DNA damage, Taeniopygia guttata"
+xref: Reactome:REACT_90364 "Regulation of NUDC by phosphorylation, Canis familiaris"
+xref: Reactome:REACT_90426 "Phosphorylation of Wee1 kinase by Chk1, Mus musculus"
+xref: Reactome:REACT_90449 "Phosphorylation of Cyclin E:Cdk2 complexes by Wee-1, Canis familiaris"
+xref: Reactome:REACT_90562 "Regulation of NUDC by phosphorylation, Drosophila melanogaster"
+xref: Reactome:REACT_9057 "Phosphorylation of Cyclin A:Cdk2 at Tyr 15, Homo sapiens"
+xref: Reactome:REACT_9067 "CAK-mediated phosphorylation of Cyclin E:Cdk2, Homo sapiens"
+xref: Reactome:REACT_90675 "Phosphorylation (Ser5) of RNA pol II CTD, Caenorhabditis elegans"
+xref: Reactome:REACT_907 "Mcm2-7 is phosphorylated by DDK, Homo sapiens"
+xref: Reactome:REACT_9070 "CAK-mediated phosphorylation of Cyclin A:Cdk2, Homo sapiens"
+xref: Reactome:REACT_908 "Phosphorylation of AKT2 by PDK1, Homo sapiens"
+xref: Reactome:REACT_90917 "Phosphorylation of Wee1 kinase by Chk1, Canis familiaris"
+xref: Reactome:REACT_91050 "SOS phosphorylation and dissociation (IRS, Crk), Mus musculus"
+xref: Reactome:REACT_91062 "Phosphorylation of Cyclin E2:Cdk2 complexes by Myt1, Bos taurus"
+xref: Reactome:REACT_91085 "Inactivation of Wee1 kinase, Danio rerio"
+xref: Reactome:REACT_91156 "Phosphorylation and activation of CHK2 by ATM, Gallus gallus"
+xref: Reactome:REACT_91157 "Phosphorylation (Ser5) of RNA pol II CTD, Saccharomyces cerevisiae"
+xref: Reactome:REACT_91196 "Phosphorylation of 4E-BP1 by activated mTORC1, Mus musculus"
+xref: Reactome:REACT_91197 "Phosphorylation and activation of eIF4B by activated S6K1, Mus musculus"
+xref: Reactome:REACT_91240 "Phosphorylation of Cdc25A at Ser-123 by Chk2, Xenopus tropicalis"
+xref: Reactome:REACT_91263 "Down Regulation of Emi1 through Phosphorylation of Emi1, Gallus gallus"
+xref: Reactome:REACT_91382 "SOS phosphorylation and dissociation (IRS), Danio rerio"
+xref: Reactome:REACT_91470 "Regulation of KIF20A (MKL2) by phosphorylation, Canis familiaris"
+xref: Reactome:REACT_91501 "PIP2 conversion to PIP3, Bos taurus"
+xref: Reactome:REACT_91541 "Phosphorylation of phospho-(Ser45,Thr41,Ser37) at Ser33 by GSK-3, Rattus norvegicus"
+xref: Reactome:REACT_91574 "Phosphorylation of DLC2 by MAPK-8, Rattus norvegicus"
+xref: Reactome:REACT_91643 "Phosphorylation of Cyclin D1 at T286 by glycogen synthase kinase-3 beta, Drosophila melanogaster"
+xref: Reactome:REACT_91684 "Phosphorylation of the SA2 Cohesin Complex, Drosophila melanogaster"
+xref: Reactome:REACT_91760 "Regulation of KIF23 (MKLP1) by phosphorylation, Danio rerio"
+xref: Reactome:REACT_91937 "Phosphorylation of APC component of the destruction complex, Bos taurus"
+xref: Reactome:REACT_92033 "Inactivation of Myt1 kinase, Caenorhabditis elegans"
+xref: Reactome:REACT_92108 "Myt-1 mediated phosphorylation of Cyclin A:Cdc2, Rattus norvegicus"
+xref: Reactome:REACT_92126 "Activation of S6K1, Oryza sativa"
+xref: Reactome:REACT_92148 "Autophosphorylation of PAK-2p34 in the activation loop, Danio rerio"
+xref: Reactome:REACT_92219 "Phosphorylation of PDE3B, Caenorhabditis elegans"
+xref: Reactome:REACT_92247 "Phosphorylation of the Emi1 DSGxxS degron by Plk1, Canis familiaris"
+xref: Reactome:REACT_92407 "Regulation of KIF23 (MKLP1) by phosphorylation, Canis familiaris"
+xref: Reactome:REACT_92735 "Autophosphorylation of PAK-2p34 in the activation loop, Taeniopygia guttata"
+xref: Reactome:REACT_92736 "Phosphorylation of L1 by ERK, Gallus gallus"
+xref: Reactome:REACT_92804 "Phosphorylation of Wee1 kinase by Chk1, Danio rerio"
+xref: Reactome:REACT_92852 "SOS phosphorylation and dissociation (SHC), Canis familiaris"
+xref: Reactome:REACT_92889 "Phosphorylation of TSC2 by PKB, Sus scrofa"
+xref: Reactome:REACT_92915 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Danio rerio"
+xref: Reactome:REACT_92929 "RAF1 phosphorylates MEK1, Danio rerio"
+xref: Reactome:REACT_92951 "Phosphorylation and activation of Chk1 by ATM, Canis familiaris"
+xref: Reactome:REACT_93018 "RAF1 phosphorylates MEK1, Bos taurus"
+xref: Reactome:REACT_93105 "Phosphorylation of cPLA2 by ERK-2, Rattus norvegicus"
+xref: Reactome:REACT_93124 "CAK-mediated phosphorylation of Cyclin A:Cdc2 complexes, Mus musculus"
+xref: Reactome:REACT_93149 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Dictyostelium discoideum"
+xref: Reactome:REACT_93166 "Phosphorylation and activation of Chk1 by ATM, Taeniopygia guttata"
+xref: Reactome:REACT_93219 "Phosphorylation of Cyclin D1 at T286 by glycogen synthase kinase-3 beta, Xenopus tropicalis"
+xref: Reactome:REACT_93221 "Phosphoryation of phospho- (Ser45, Thr41) beta-catenin at Ser37 by GSK-3, Xenopus tropicalis"
+xref: Reactome:REACT_93346 "Wee1-mediated phosphorylation of Cyclin A:phospho-Cdc2 complexes, Mus musculus"
+xref: Reactome:REACT_93366 "Phosphorylation of cPLA2 by ERK-2, Canis familiaris"
+xref: Reactome:REACT_93414 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Drosophila melanogaster"
+xref: Reactome:REACT_93440 "Regulation of KIF20A (MKL2) by phosphorylation, Taeniopygia guttata"
+xref: Reactome:REACT_93441 "Regulation of KIF23 (MKLP1) by phosphorylation, Gallus gallus"
+xref: Reactome:REACT_93613 "CAK-mediated phosphorylation of Cyclin A:Cdk2, Rattus norvegicus"
+xref: Reactome:REACT_93615 "Phosphorylation of MDM2 at serine-395 by ATM kinase, Bos taurus"
+xref: Reactome:REACT_937 "Phosphorylation of BRCA1 at multiple sites by ATM, Homo sapiens"
+xref: Reactome:REACT_93706 "RAF1 phosphorylates MEK1, Canis familiaris"
+xref: Reactome:REACT_93746 "Phosphorylation of Cyclin A:Cdk2 at Tyr 15, Mus musculus"
+xref: Reactome:REACT_93878 "Phosphorylation of Cdc25A at Ser-123 in response to DNA damage, Gallus gallus"
+xref: Reactome:REACT_94017 "SOS phosphorylation and dissociation (IRS, Crk), Bos taurus"
+xref: Reactome:REACT_94113 "Phosphorylation of Cx43 by c-src, Canis familiaris"
+xref: Reactome:REACT_94151 "Phosphorylation of Wee1 kinase by Chk1, Xenopus tropicalis"
+xref: Reactome:REACT_94248 "SOS phosphorylation and dissociation (SHC), Bos taurus"
+xref: Reactome:REACT_94258 "Phosphorylation of p53 at ser-15 by ATM kinase, Sus scrofa"
+xref: Reactome:REACT_94298 "Phosphorylation of Cyclin B1 in the CRS domain, Danio rerio"
+xref: Reactome:REACT_94397 "Orc1 is phosphorylated by cyclin A/CDK2, Danio rerio"
+xref: Reactome:REACT_94428 "Phosphorylation of PD-1, Bos taurus"
+xref: Reactome:REACT_94452 "Phosphorylation of MDC1/NFBD1 by ATM (within 2 c-term BRCT domains), Bos taurus"
+xref: Reactome:REACT_94464 "Phosphorylation and activation of eIF4B by activated S6K1, Danio rerio"
+xref: Reactome:REACT_94562 "Phosphorylation of the Scc1:Cohesion Complex, Caenorhabditis elegans"
+xref: Reactome:REACT_94615 "SOS phosphorylation and dissociation (IRS, Crk), Rattus norvegicus"
+xref: Reactome:REACT_94784 "Phosphorylation of Cyclin D1 at T286 by glycogen synthase kinase-3 beta, Rattus norvegicus"
+xref: Reactome:REACT_94817 "Phosphorylation of the SA2 Cohesin Complex, Rattus norvegicus"
+xref: Reactome:REACT_94947 "Autophosphorylation of PAK-2p34 in the activation loop, Canis familiaris"
+xref: Reactome:REACT_95052 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Oryza sativa"
+xref: Reactome:REACT_95087 "Phosphorylation of the Scc1:Cohesion Complex, Bos taurus"
+xref: Reactome:REACT_95088 "Inactivation of Wee1 kinase, Mus musculus"
+xref: Reactome:REACT_95089 "Phosphorylation of Cyclin E:Cdk2 complexes by Wee-1, Bos taurus"
+xref: Reactome:REACT_95155 "Regulation of NUDC by phosphorylation, Taeniopygia guttata"
+xref: Reactome:REACT_95163 "CAK-mediated phosphorylation of Cyclin A:Cdk2, Mus musculus"
+xref: Reactome:REACT_95437 "Phosphorylation of phospho-(Ser45,Thr41,Ser37) at Ser33 by GSK-3, Drosophila melanogaster"
+xref: Reactome:REACT_95461 "Phosphorylation of proteins involved in the G1/S transition by Cyclin A:Cdk2, Bos taurus"
+xref: Reactome:REACT_95504 "Phosphorylation of Cdc25C at Ser216, Xenopus tropicalis"
+xref: Reactome:REACT_95769 "PIP2 conversion to PIP3, Xenopus tropicalis"
+xref: Reactome:REACT_96 "Phosphorylation of Cyclin D:Cdk4/6 complexes, Homo sapiens"
+xref: Reactome:REACT_96039 "Myt-1 mediated phosphorylation of Cyclin A:Cdc2, Canis familiaris"
+xref: Reactome:REACT_96088 "Phosphorylation of PDE3B, Sus scrofa"
+xref: Reactome:REACT_96097 "SOS phosphorylation and dissociation (IRS), Rattus norvegicus"
+xref: Reactome:REACT_96102 "Phosphorylation of Cx43 by c-src, Gallus gallus"
+xref: Reactome:REACT_96129 "Phosphorylation and activation of eIF4G by activated S6K1, Taeniopygia guttata"
+xref: Reactome:REACT_96200 "Regulation of NUDC by phosphorylation, Gallus gallus"
+xref: Reactome:REACT_96208 "Phosphorylation of COP1 at Ser-387 by ATM, Sus scrofa"
+xref: Reactome:REACT_96218 "Wee1-mediated phosphorylation of Cyclin A:phospho-Cdc2 complexes, Drosophila melanogaster"
+xref: Reactome:REACT_96356 "Free APC/C phosphorylated by Plk1, Rattus norvegicus"
+xref: Reactome:REACT_96461 "Phosphorylation of L1 by CK-II, Bos taurus"
+xref: Reactome:REACT_96468 "Autophosphorylation of PAK-2p34 in the activation loop, Mus musculus"
+xref: Reactome:REACT_96483 "Phosphorylation of COP1 at Ser-387 by ATM, Gallus gallus"
+xref: Reactome:REACT_96500 "RAF1 phosphorylates MEK2, Gallus gallus"
+xref: Reactome:REACT_96524 "Activation of Cdc25C, Xenopus tropicalis"
+xref: Reactome:REACT_96656 "Plk1-mediated phosphorylation of Nlp, Rattus norvegicus"
+xref: Reactome:REACT_96666 "Phosphorylation and activation of CHK2 by ATM, Saccharomyces cerevisiae"
+xref: Reactome:REACT_96758 "Phosphorylation of Cdc25A at Ser-123 by Chk2, Canis familiaris"
+xref: Reactome:REACT_96793 "Activation of S6K1, Danio rerio"
+xref: Reactome:REACT_96797 "CAK-mediated phosphorylation of Cyclin E:Cdk2, Rattus norvegicus"
+xref: Reactome:REACT_96877 "Phosphorylation of MDM2 at serine-395 by ATM kinase, Sus scrofa"
+xref: Reactome:REACT_96899 "Phosphorylation of TSC2 by PKB, Rattus norvegicus"
+xref: Reactome:REACT_96968 "Cdc6 protein is phosphorylated by CDK, Mus musculus"
+xref: Reactome:REACT_97193 "Phosphorylation and activation of eIF4G by activated S6K1, Canis familiaris"
+xref: Reactome:REACT_97218 "Orc1 is phosphorylated by cyclin A/CDK2, Xenopus tropicalis"
+xref: Reactome:REACT_97282 "Activation of S6K1, Sus scrofa"
+xref: Reactome:REACT_97299 "Phosphorylation of Cyclin E2:Cdk2 complexes by Myt1, Mus musculus"
+xref: Reactome:REACT_97458 "Activation of the Anaphase Promoting Complex (APC) by PLK1, Dictyostelium discoideum"
+xref: Reactome:REACT_97577 "Myt-1 mediated phosphorylation of Cyclin A:Cdc2, Bos taurus"
+xref: Reactome:REACT_97661 "Mcm2-7 is phosphorylated by DDK, Gallus gallus"
+xref: Reactome:REACT_97667 "Phosphorylation of complexed TSC2 by PKB, Canis familiaris"
+xref: Reactome:REACT_97748 "Phosphorylation of cPLA2 by ERK-2, Mus musculus"
+xref: Reactome:REACT_97759 "Phosphorylation of Cx43 by c-src, Danio rerio"
+xref: Reactome:REACT_97847 "Phosphorylation of Cdc25A at Ser-123 by Chk2, Mus musculus"
+xref: Reactome:REACT_97905 "Phosphorylation of BRCA1 at multiple sites by ATM, Xenopus tropicalis"
+xref: Reactome:REACT_98024 "Myt-1 mediated phosphorylation of Cyclin A:Cdc2, Mus musculus"
+xref: Reactome:REACT_98050 "Phosphorylation of Cdc25C at Ser216, Canis familiaris"
+xref: Reactome:REACT_98066 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Saccharomyces cerevisiae"
+xref: Reactome:REACT_98109 "Regulation of NUDC by phosphorylation, Mus musculus"
+xref: Reactome:REACT_98176 "Phosphorylation of phospho-(Ser45,Thr41,Ser37) at Ser33 by GSK-3, Bos taurus"
+xref: Reactome:REACT_98213 "Phosphorylation of Cdc25A at Ser-123 in response to DNA damage, Xenopus tropicalis"
+xref: Reactome:REACT_98253 "RAF1 phosphorylates MEK2, Bos taurus"
+xref: Reactome:REACT_98296 "Phosphorylation of Cyclin B1 in the CRS domain, Drosophila melanogaster"
+xref: Reactome:REACT_98373 "Myt-1 mediated phosphorylation of Cyclin A:Cdc2, Drosophila melanogaster"
+xref: Reactome:REACT_98378 "Phosphorylation of COP1 at Ser-387 by ATM, Danio rerio"
+xref: Reactome:REACT_98395 "Phosphorylation and activation of Chk1 by ATM, Arabidopsis thaliana"
+xref: Reactome:REACT_98434 "Phosphorylation and inactivation of eEF2K by activated S6K1, Taeniopygia guttata"
+xref: Reactome:REACT_98436 "Phosphorylation of 4E-BP1 by activated mTORC1, Gallus gallus"
+xref: Reactome:REACT_98443 "Inactivation of Wee1 kinase, Gallus gallus"
+xref: Reactome:REACT_98493 "Partial autophosphorylation of PAK-2 at Ser-19, Ser-20, Ser-55, Ser-192, and Ser-197, Drosophila melanogaster"
+xref: Reactome:REACT_98558 "Autophosphorylation of PAK-2p34 in the activation loop, Saccharomyces cerevisiae"
+xref: Reactome:REACT_98560 "Phosphorylation and activation of CHK2 by ATM, Xenopus tropicalis"
+xref: Reactome:REACT_98663 "Regulation of KIF23 (MKLP1) by phosphorylation, Bos taurus"
+xref: Reactome:REACT_98708 "Phosphorylation of phospho-(Ser45 ) at Thr 41 by GSK-3, Drosophila melanogaster"
+xref: Reactome:REACT_98731 "Phosphorylation of Cdc25A at Ser-123 by Chk1, Danio rerio"
+xref: Reactome:REACT_98738 "Phosphorylation of TSC2 by PKB, Danio rerio"
+xref: Reactome:REACT_98741 "Phosphorylation of beta-catenin at Ser45 by CK1 alpha, Bos taurus"
+xref: Reactome:REACT_98779 "Phosphorylation of Cx43 by c-src, Taeniopygia guttata"
+xref: Reactome:REACT_988 "Phosphorylation of MDM2 at serine-395 by ATM kinase, Homo sapiens"
+xref: Reactome:REACT_98847 "Phosphorylation of complexed TSC2 by PKB, Mus musculus"
+xref: Reactome:REACT_98908 "Phosphorylation of phospho-(Ser45 ) at Thr 41 by GSK-3, Rattus norvegicus"
+xref: Reactome:REACT_98913 "Phosphorylation of PD-1, Canis familiaris"
+xref: Reactome:REACT_98971 "Phosphorylation of AKT2 by PDK1, Rattus norvegicus"
+xref: Reactome:REACT_98996 "Free APC/C phosphorylated by Plk1, Danio rerio"
+xref: Reactome:REACT_99025 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Taeniopygia guttata"
+xref: Reactome:REACT_99053 "CAK-mediated phosphorylation of Cyclin E:Cdk2, Sus scrofa"
+xref: Reactome:REACT_99141 "Phosphorylation of NBS1 by ATM, Bos taurus"
+xref: Reactome:REACT_99158 "Inactivation of Wee1 kinase, Drosophila melanogaster"
+xref: Reactome:REACT_99207 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Taeniopygia guttata"
+xref: Reactome:REACT_99231 "Phosphorylation of AKT2 by PDK1, Danio rerio"
+xref: Reactome:REACT_99266 "Activation of the Anaphase Promoting Complex (APC) by PLK1, Caenorhabditis elegans"
+xref: Reactome:REACT_99302 "Phosphorylation of Cyclin D:Cdk4/6 complexes, Sus scrofa"
+xref: Reactome:REACT_99311 "RAF1 phosphorylates MEK1, Mus musculus"
+xref: Reactome:REACT_9955 "Phosphorylation of phospho-(Ser45 ) at Thr 41 by GSK-3, Homo sapiens"
+xref: Reactome:REACT_99556 "Phosphorylation of Ribosomal protein S6 by activated S6K1, Mus musculus"
+xref: Reactome:REACT_99560 "RAF1 phosphorylates MEK2, Canis familiaris"
+xref: Reactome:REACT_9959 "Phosphoryation of phospho- (Ser45, Thr41) beta-catenin at Ser37 by GSK-3, Homo sapiens"
+xref: Reactome:REACT_99595 "Phosphorylation of Cyclin A:Cdk2 at Tyr 15, Bos taurus"
+xref: Reactome:REACT_99713 "Phosphorylation of DLC2 by MAPK-8, Taeniopygia guttata"
+xref: Reactome:REACT_9978 "Phosphorylation of beta-catenin at Ser45 by CK1 alpha, Homo sapiens"
+xref: Reactome:REACT_99785 "Phosphorylation of phospho-(Ser45 ) at Thr 41 by GSK-3, Canis familiaris"
+xref: Reactome:REACT_9983 "Phosphorylation of APC component of the destruction complex, Homo sapiens"
+xref: Reactome:REACT_9987 "Phosphorylation of phospho-(Ser45,Thr41,Ser37) at Ser33 by GSK-3, Homo sapiens"
+xref: Reactome:REACT_99929 "Phosphorylation of beta-catenin at Ser45 by CK1 alpha, Gallus gallus"
+xref: Reactome:REACT_99966 "Intermolecular autophosphorylation of ATM within dimeric ATM complexes, Schizosaccharomyces pombe"
+xref: Reactome:REACT_9997 "Phosphorylation of Cx43 by c-src, Homo sapiens"
+is_a: GO:0003674 ! molecular_function
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0016491
+name: oxidoreductase activity
+namespace: molecular_function
+def: "Catalysis of an oxidation-reduction (redox) reaction, a reversible chemical reaction in which the oxidation state of an atom or atoms within a molecule is altered. One substrate acts as a hydrogen or electron donor and becomes oxidized, while the other acts as hydrogen or electron acceptor and becomes reduced." [GOC:go_curators]
+comment: Note that enzymes of class EC:1.97.-.- should also be annotated to this term.
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_mouse
+subset: goslim_pir
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "oxidoreductase activity, acting on other substrates" NARROW []
+synonym: "redox activity" EXACT []
+xref: EC:1
+xref: Reactome:REACT_102858 "Diiodinated tyrosine can be deiodinated, Mus musculus"
+xref: Reactome:REACT_102973 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR1], Canis familiaris"
+xref: Reactome:REACT_103874 "Monoiodinated tyrosine can be deiodinated, Canis familiaris"
+xref: Reactome:REACT_104604 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR1], Danio rerio"
+xref: Reactome:REACT_105062 "Monoiodinated tyrosine can be deiodinated, Danio rerio"
+xref: Reactome:REACT_105121 "Monoiodinated tyrosine can be deiodinated, Caenorhabditis elegans"
+xref: Reactome:REACT_106088 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR1], Rattus norvegicus"
+xref: Reactome:REACT_106276 "Monoiodinated tyrosine can be deiodinated, Rattus norvegicus"
+xref: Reactome:REACT_107002 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR2], Sus scrofa"
+xref: Reactome:REACT_107467 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR2], Rattus norvegicus"
+xref: Reactome:REACT_108745 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR1], Taeniopygia guttata"
+xref: Reactome:REACT_109500 "Monoiodinated tyrosine can be deiodinated, Bos taurus"
+xref: Reactome:REACT_110582 "Diiodinated tyrosine can be deiodinated, Rattus norvegicus"
+xref: Reactome:REACT_115316 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR1], Drosophila melanogaster"
+xref: Reactome:REACT_15389 "Monoiodinated tyrosine can be deiodinated, Homo sapiens"
+xref: Reactome:REACT_15410 "Diiodinated tyrosine can be deiodinated, Homo sapiens"
+xref: Reactome:REACT_17006 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR1], Homo sapiens"
+xref: Reactome:REACT_17042 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR2], Homo sapiens"
+xref: Reactome:REACT_29212 "Diiodinated tyrosine can be deiodinated, Canis familiaris"
+xref: Reactome:REACT_30160 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR2], Mus musculus"
+xref: Reactome:REACT_31762 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR1], Gallus gallus"
+xref: Reactome:REACT_32960 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR1], Bos taurus"
+xref: Reactome:REACT_34705 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR1], Mus musculus"
+xref: Reactome:REACT_44470 "Monoiodinated tyrosine can be deiodinated, Mus musculus"
+xref: Reactome:REACT_78923 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR2], Taeniopygia guttata"
+xref: Reactome:REACT_84842 "Diiodinated tyrosine can be deiodinated, Gallus gallus"
+xref: Reactome:REACT_86178 "Monoiodinated tyrosine can be deiodinated, Xenopus tropicalis"
+xref: Reactome:REACT_88304 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR2], Bos taurus"
+xref: Reactome:REACT_89057 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR2], Gallus gallus"
+xref: Reactome:REACT_90394 "Diiodinated tyrosine can be deiodinated, Xenopus tropicalis"
+xref: Reactome:REACT_91638 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR1], Arabidopsis thaliana"
+xref: Reactome:REACT_91952 "Monoiodinated tyrosine can be deiodinated, Gallus gallus"
+xref: Reactome:REACT_92075 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR1], Xenopus tropicalis"
+xref: Reactome:REACT_92434 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR2], Canis familiaris"
+xref: Reactome:REACT_93539 "Diiodinated tyrosine can be deiodinated, Drosophila melanogaster"
+xref: Reactome:REACT_93974 "Diiodinated tyrosine can be deiodinated, Taeniopygia guttata"
+xref: Reactome:REACT_95169 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR2], Danio rerio"
+xref: Reactome:REACT_95558 "Monoiodinated tyrosine can be deiodinated, Sus scrofa"
+xref: Reactome:REACT_95573 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR1], Caenorhabditis elegans"
+xref: Reactome:REACT_97234 "Diiodinated tyrosine can be deiodinated, Caenorhabditis elegans"
+xref: Reactome:REACT_97568 "Diiodinated tyrosine can be deiodinated, Sus scrofa"
+xref: Reactome:REACT_97851 "Diiodinated tyrosine can be deiodinated, Bos taurus"
+xref: Reactome:REACT_98022 "Monoiodinated tyrosine can be deiodinated, Drosophila melanogaster"
+xref: Reactome:REACT_99085 "palmitoyl-CoA + 2 NADPH + 2 H+ => hexadecanol + 2 NADP+ [FAR1], Oryza sativa"
+xref: Reactome:REACT_99794 "Diiodinated tyrosine can be deiodinated, Danio rerio"
+xref: Reactome:REACT_99989 "Monoiodinated tyrosine can be deiodinated, Taeniopygia guttata"
+is_a: GO:0003674 ! molecular_function
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0016746
+name: transferase activity, transferring acyl groups
+namespace: molecular_function
+alt_id: GO:0008415
+def: "Catalysis of the transfer of an acyl group from one compound (donor) to another (acceptor)." [GOC:jl, ISBN:0198506732]
+subset: goslim_chembl
+subset: goslim_generic
+subset: gosubset_prok
+synonym: "acyltransferase activity" EXACT []
+xref: EC:2.3
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0016757
+name: transferase activity, transferring glycosyl groups
+namespace: molecular_function
+alt_id: GO:0016932
+def: "Catalysis of the transfer of a glycosyl group from one compound (donor) to another (acceptor)." [GOC:jl, ISBN:0198506732]
+comment: Note that enzymes of class EC:2.4.99.- should also be annotated to this term.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "glycosyltransferase activity" EXACT []
+synonym: "transferase activity, transferring other glycosyl groups" NARROW []
+synonym: "transglycosidase activity" EXACT []
+synonym: "transglycosylase activity" EXACT []
+xref: EC:2.4
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0016765
+name: transferase activity, transferring alkyl or aryl (other than methyl) groups
+namespace: molecular_function
+alt_id: GO:0016766
+def: "Catalysis of the transfer of an alkyl or aryl (but not methyl) group from one compound (donor) to another (acceptor)." [GOC:jl, ISBN:0198506732]
+subset: goslim_chembl
+subset: goslim_generic
+subset: gosubset_prok
+synonym: "transferase activity, transferring alkyl or aryl groups, other than methyl groups" EXACT []
+xref: EC:2.5
+xref: EC:2.5.1
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0016779
+name: nucleotidyltransferase activity
+namespace: molecular_function
+def: "Catalysis of the transfer of a nucleotidyl group to a reactant." [ISBN:0198506732]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_yeast
+subset: gosubset_prok
+xref: EC:2.7.7
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0016791
+name: phosphatase activity
+namespace: molecular_function
+alt_id: GO:0003869
+alt_id: GO:0016302
+def: "Catalysis of the hydrolysis of phosphoric monoesters, releasing inorganic phosphate." [EC:3.1.3, EC:3.1.3.41, GOC:curators, GOC:pg]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "4-nitrophenylphosphatase activity" NARROW []
+synonym: "4-nitrophenylphosphate phosphohydrolase activity" NARROW [EC:3.1.3.41]
+synonym: "ecto-p-nitrophenyl phosphatase activity" NARROW [EC:3.1.3.41]
+synonym: "K-pNPPase activity" NARROW [EC:3.1.3.41]
+synonym: "nitrophenyl phosphatase activity" NARROW [EC:3.1.3.41]
+synonym: "NPPase activity" NARROW [EC:3.1.3.41]
+synonym: "p-nitrophenylphosphatase activity" NARROW [EC:3.1.3.41]
+synonym: "p-nitrophenylphosphate phosphohydrolase activity" NARROW [EC:3.1.3.41]
+synonym: "para-nitrophenyl phosphatase activity" NARROW [EC:3.1.3.41]
+synonym: "phosphatase" RELATED []
+synonym: "phosphoric monoester hydrolase activity" EXACT []
+synonym: "PNPPase activity" NARROW [EC:3.1.3.41]
+xref: EC:3.1.3
+xref: EC:3.1.3.41
+xref: MetaCyc:4-NITROPHENYLPHOSPHATASE-RXN
+xref: RHEA:21667
+is_a: GO:0003674 ! molecular_function
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0016798
+name: hydrolase activity, acting on glycosyl bonds
+namespace: molecular_function
+def: "Catalysis of the hydrolysis of any glycosyl bond." [GOC:jl]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "glycosidase activity" EXACT []
+synonym: "glycosylase" NARROW []
+synonym: "N-glycosylase" NARROW []
+xref: EC:3.2
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0016810
+name: hydrolase activity, acting on carbon-nitrogen (but not peptide) bonds
+namespace: molecular_function
+def: "Catalysis of the hydrolysis of any carbon-nitrogen bond, C-N, with the exception of peptide bonds." [GOC:jl]
+comment: Note that enzymes of class EC:3.5.99.- should also be annotated to this term.
+subset: goslim_chembl
+subset: goslim_generic
+subset: gosubset_prok
+synonym: "hydrolase activity, acting on carbon-nitrogen (but not peptide) bonds, in other compounds" NARROW []
+xref: EC:3.5
+xref: Reactome:REACT_27208 "acetylglucosamine-inositol is deacetylated by Mca, Mycobacterium tuberculosis"
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0016829
+name: lyase activity
+namespace: molecular_function
+def: "Catalysis of the cleavage of C-C, C-O, C-N and other bonds by other means than by hydrolysis or oxidation, or conversely adding a group to a double bond. They differ from other enzymes in that two substrates are involved in one reaction direction, but only one in the other direction. When acting on the single substrate, a molecule is eliminated and this generates either a new double bond or a new ring." [EC:4.-.-.-, ISBN:0198547684]
+comment: Note that enzymes of class EC:4.99.-.- should also be annotated to this term.
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "other lyase activity" NARROW []
+xref: EC:4
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0016853
+name: isomerase activity
+namespace: molecular_function
+def: "Catalysis of the geometric or structural changes within one molecule. Isomerase is the systematic name for any enzyme of EC class 5." [ISBN:0198506732]
+comment: Note that enzymes of class EC:5.99.-.- should also be annotated to this term.
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "other isomerase activity" NARROW []
+xref: EC:5
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0016874
+name: ligase activity
+namespace: molecular_function
+def: "Catalysis of the joining of two substances, or two groups within a single molecule, with the concomitant hydrolysis of the diphosphate bond in ATP or a similar triphosphate." [EC:6, GOC:mah]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_mouse
+subset: goslim_pir
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "synthetase activity" EXACT [GOC:jh2]
+xref: EC:6
+xref: Reactome:REACT_115603 "Ligation of DNA at sites of patch replacement, Gallus gallus"
+xref: Reactome:REACT_116018 "Ligation of newly synthesized repair patch to incised DNA in GG-NER, Gallus gallus"
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0016887
+name: ATPase activity
+namespace: molecular_function
+alt_id: GO:0004002
+def: "Catalysis of the reaction: ATP + H2O = ADP + phosphate + 2 H+. May or may not be coupled to another reaction." [EC:3.6.1.3, GOC:jl]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "(Ca2+ + Mg2+)-ATPase" NARROW [EC:3.6.1.3]
+synonym: "adenosine 5'-triphosphatase activity" EXACT [EC:3.6.1.3]
+synonym: "adenosine triphosphatase activity" EXACT [EC:3.6.1.3]
+synonym: "adenosinetriphosphatase activity" EXACT []
+synonym: "ATP hydrolase activity" EXACT [EC:3.6.1.3]
+synonym: "ATP monophosphatase activity" EXACT [EC:3.6.1.3]
+synonym: "ATP phosphohydrolase activity" EXACT []
+synonym: "complex V (mitochondrial electron transport)" RELATED [EC:3.6.1.3]
+synonym: "HCO3--ATPase" NARROW [EC:3.6.1.3]
+synonym: "SV40 T-antigen" RELATED [EC:3.6.1.3]
+xref: EC:3.6.1.3
+xref: MetaCyc:ADENOSINETRIPHOSPHATASE-RXN
+xref: Reactome:REACT_100141 "Trafficking of GluR2-containing AMPA receptors to synapse, Canis familiaris"
+xref: Reactome:REACT_108873 "Trafficking of GluR2-containing AMPA receptors to synapse, Bos taurus"
+xref: Reactome:REACT_110992 "Trafficking of GluR2-containing AMPA receptors to synapse, Danio rerio"
+xref: Reactome:REACT_113271 "Trafficking of GluR2-containing AMPA receptors to synapse, Xenopus tropicalis"
+xref: Reactome:REACT_18320 "Trafficking of GluR2-containing AMPA receptors to synapse, Homo sapiens"
+xref: Reactome:REACT_27184 "ESCRT Disassembly, Homo sapiens"
+xref: Reactome:REACT_33329 "Trafficking of GluR2-containing AMPA receptors to synapse, Gallus gallus"
+xref: Reactome:REACT_79964 "Trafficking of GluR2-containing AMPA receptors to synapse, Mus musculus"
+xref: Reactome:REACT_84196 "Trafficking of GluR2-containing AMPA receptors to synapse, Drosophila melanogaster"
+xref: Reactome:REACT_87020 "Trafficking of GluR2-containing AMPA receptors to synapse, Rattus norvegicus"
+xref: Reactome:REACT_89934 "Trafficking of GluR2-containing AMPA receptors to synapse, Taeniopygia guttata"
+xref: RHEA:13068
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0019748
+name: secondary metabolic process
+namespace: biological_process
+def: "The chemical reactions and pathways resulting in many of the chemical changes of compounds that are not necessarily required for growth and maintenance of cells, and are often unique to a taxon. In multicellular organisms secondary metabolism is generally carried out in specific cell types, and may be useful for the organism as a whole. In unicellular organisms, secondary metabolism is often used for the production of antibiotics or for the utilization and acquisition of unusual nutrients." [GOC:go_curators]
+subset: goslim_aspergillus
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "secondary metabolism" EXACT []
+synonym: "secondary metabolite metabolic process" EXACT []
+synonym: "secondary metabolite metabolism" EXACT []
+xref: Wikipedia:Secondary_metabolism
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0019843
+name: rRNA binding
+namespace: molecular_function
+def: "Interacting selectively and non-covalently with ribosomal RNA." [GOC:jl]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+is_a: GO:0003723 ! RNA binding
+
+[Term]
+id: GO:0019899
+name: enzyme binding
+namespace: molecular_function
+def: "Interacting selectively and non-covalently with any enzyme." [GOC:jl]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0021700
+name: developmental maturation
+namespace: biological_process
+def: "A developmental process, independent of morphogenetic (shape) change, that is required for an anatomical structure, cell or cellular component to attain its fully functional state." [GO_REF:0000021, GOC:cls, GOC:dgh, GOC:dph, GOC:jid, GOC:mtg_15jun06]
+comment: This term was added by GO_REF:0000021.
+subset: goslim_chembl
+subset: goslim_generic
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0022607
+name: cellular component assembly
+namespace: biological_process
+alt_id: GO:0071844
+def: "The aggregation, arrangement and bonding together of a cellular component." [GOC:isa_complete]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: gosubset_prok
+synonym: "cell structure assembly" EXACT []
+synonym: "cellular component assembly at cellular level" EXACT []
+is_a: GO:0008150 ! biological_process
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0022618
+name: ribonucleoprotein complex assembly
+namespace: biological_process
+def: "The aggregation, arrangement and bonding together of proteins and RNA molecules to form a ribonucleoprotein complex." [GOC:jl]
+subset: goslim_chembl
+subset: goslim_generic
+subset: gosubset_prok
+synonym: "protein-RNA complex assembly" EXACT []
+synonym: "RNA-protein complex assembly" EXACT []
+synonym: "RNP complex assembly" EXACT []
+is_a: GO:0065003 ! macromolecular complex assembly
+
+[Term]
+id: GO:0022857
+name: transmembrane transporter activity
+namespace: molecular_function
+alt_id: GO:0005386
+alt_id: GO:0015646
+def: "Enables the transfer of a substance from one side of a membrane to the other." [GOC:mtg_transport, ISBN:0815340729]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+xref: Reactome:REACT_100033 "GLUT9 transports glucose, fructose and urate, Gallus gallus"
+xref: Reactome:REACT_106735 "GLUT9 transports glucose, fructose and urate, Xenopus tropicalis"
+xref: Reactome:REACT_111088 "Egress of internalized antigen to the cytosol via sec61, Homo sapiens"
+xref: Reactome:REACT_111933 "GLUT9 transports glucose, fructose and urate, Plasmodium falciparum"
+xref: Reactome:REACT_113047 "GLUT9 transports glucose, fructose and urate, Dictyostelium discoideum"
+xref: Reactome:REACT_113116 "GLUT9 transports glucose, fructose and urate, Mycobacterium tuberculosis"
+xref: Reactome:REACT_113829 "GLUT9 transports glucose, fructose and urate, Arabidopsis thaliana"
+xref: Reactome:REACT_114161 "GLUT9 transports glucose, fructose and urate, Oryza sativa"
+xref: Reactome:REACT_19288 "GLUT9 transports glucose, fructose and urate, Homo sapiens"
+xref: Reactome:REACT_77235 "GLUT9 transports glucose, fructose and urate, Canis familiaris"
+xref: Reactome:REACT_81225 "GLUT9 transports glucose, fructose and urate, Bos taurus"
+xref: Reactome:REACT_88503 "GLUT9 transports glucose, fructose and urate, Taeniopygia guttata"
+xref: Reactome:REACT_91849 "GLUT9 transports glucose, fructose and urate, Mus musculus"
+xref: Reactome:REACT_94185 "GLUT9 transports glucose, fructose and urate, Rattus norvegicus"
+is_a: GO:0003674 ! molecular_function
+relationship: part_of GO:0055085 ! transmembrane transport
+
+[Term]
+id: GO:0030154
+name: cell differentiation
+namespace: biological_process
+def: "The process in which relatively unspecialized cells, e.g. embryonic or regenerative cells, acquire specialized structural and/or functional features that characterize the cells, tissues, or organs of the mature organism or some other relatively stable phase of the organism's life history. Differentiation includes the processes involved in commitment of a cell to a specific fate and its subsequent development to the mature state." [ISBN:0198506732]
+subset: goslim_agr
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_plant
+subset: gosubset_prok
+xref: Wikipedia:Cellular_differentiation
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0030198
+name: extracellular matrix organization
+namespace: biological_process
+def: "A process that is carried out at the cellular level which results in the assembly, arrangement of constituent parts, or disassembly of an extracellular matrix." [GOC:mah]
+subset: goslim_chembl
+subset: goslim_generic
+subset: gosubset_prok
+synonym: "extracellular matrix organisation" EXACT [GOC:curators]
+synonym: "extracellular matrix organization and biogenesis" RELATED [GOC:mah]
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0030234
+name: enzyme regulator activity
+namespace: molecular_function
+alt_id: GO:0010576
+def: "Binds to and modulates the activity of an enzyme." [GOC:dph, GOC:mah, GOC:tb]
+comment: GO:0030234 is reserved for cases when the regulator directly interacts with the enzyme. When regulation of enzyme activity is achieved without enzyme binding, or when the mechanism of regulation is unknown, instead annotate to 'regulation of catalytic activity ; GO:0050790'.
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_pir
+subset: goslim_plant
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "catalytic regulator activity" EXACT [GOC:dph]
+synonym: "enzyme modulator" EXACT []
+synonym: "metalloenzyme regulator activity" NARROW []
+is_a: GO:0003674 ! molecular_function
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0030312
+name: external encapsulating structure
+namespace: cellular_component
+def: "A structure that lies outside the plasma membrane and surrounds the entire cell. This does not include the periplasmic space." [GOC:go_curators]
+comment: The outer membrane (of gram negative bacteria) or cell wall (of yeast or Gram positive bacteria) are defined as parts of this structure, see 'external encapsulating structure part'.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_plant
+subset: gosubset_prok
+is_a: GO:0005575 ! cellular_component
+relationship: part_of GO:0005623 ! cell
+
+[Term]
+id: GO:0030533
+name: triplet codon-amino acid adaptor activity
+namespace: molecular_function
+def: "The codon binding activity of a tRNA that positions an activated amino acid, mediating its insertion at the correct point in the sequence of a nascent polypeptide chain during protein synthesis." [GOC:hjd, GOC:mtg_MIT_16mar07, ISBN:0198506732]
+comment: Note that this term can be used in place of the obsolete term 'transfer RNA ; GO:0005563'.
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+synonym: "transfer RNA" RELATED []
+synonym: "tRNA" RELATED []
+is_a: GO:0003723 ! RNA binding
+relationship: part_of GO:0006412 ! translation
+
+[Term]
+id: GO:0030555
+name: RNA modification guide activity
+namespace: molecular_function
+def: "Specifies the site of a posttranscriptional modification in an RNA molecule by base pairing with a short sequence around the target residue." [GOC:mah, PMID:12457565]
+comment: Note that this term describes the activity of a nucleic acid, usually RNA, gene product that interacts with other RNA molecules via base pairing; it should not be used to annotate proteins.
+subset: goslim_generic
+subset: goslim_yeast
+is_a: GO:0003723 ! RNA binding
+
+[Term]
+id: GO:0030674
+name: protein binding, bridging
+namespace: molecular_function
+def: "The binding activity of a molecule that brings together two or more protein molecules, or a protein and another macromolecule or complex, through a selective, non-covalent, often stoichiometric interaction, permitting those molecules to function in a coordinated way." [GOC:bf, GOC:mah, GOC:vw]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "protein-protein adaptor" NARROW []
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0030705
+name: cytoskeleton-dependent intracellular transport
+namespace: biological_process
+def: "The directed movement of substances along cytoskeletal fibers such as microfilaments or microtubules within a cell." [GOC:mah]
+subset: goslim_chembl
+subset: goslim_generic
+subset: gosubset_prok
+is_a: GO:0006810 ! transport
+relationship: occurs_in GO:0005622 ! intracellular
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0031410
+name: cytoplasmic vesicle
+namespace: cellular_component
+alt_id: GO:0016023
+def: "A vesicle found in the cytoplasm of a cell." [GOC:ai, GOC:mah, GOC:vesicles]
+subset: goslim_agr
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "cytoplasmic membrane bounded vesicle" RELATED []
+synonym: "cytoplasmic membrane-enclosed vesicle" RELATED []
+synonym: "cytoplasmic, membrane-bounded vesicle" RELATED []
+xref: NIF_Subcellular:sao180601769
+is_a: GO:0043226 ! organelle
+relationship: part_of GO:0005737 ! cytoplasm
+
+[Term]
+id: GO:0032182
+name: ubiquitin-like protein binding
+namespace: molecular_function
+def: "Interacting selectively and non-covalently with a small conjugating protein such as ubiquitin or a ubiquitin-like protein." [GOC:mah]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+synonym: "small conjugating protein binding" EXACT [GOC:dph]
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0032196
+name: transposition
+namespace: biological_process
+def: "Any process involved in mediating the movement of discrete segments of DNA between nonhomologous sites." [GOC:jp, ISBN:1555812090]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_yeast
+subset: gosubset_prok
+xref: Wikipedia:Transposon
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0034330
+name: cell junction organization
+namespace: biological_process
+def: "A process that is carried out at the cellular level which results in the assembly, arrangement of constituent parts, or disassembly of a cell junction. A cell junction is a specialized region of connection between two cells or between a cell and the extracellular matrix." [GOC:dph, GOC:jl, GOC:mah]
+subset: goslim_chembl
+subset: goslim_generic
+synonym: "cell junction assembly and maintenance" EXACT []
+synonym: "cell junction biogenesis" RELATED []
+synonym: "cell junction organisation" EXACT [GOC:mah]
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0034641
+name: cellular nitrogen compound metabolic process
+namespace: biological_process
+def: "The chemical reactions and pathways involving various organic and inorganic nitrogenous compounds, as carried out by individual cells." [GOC:mah]
+subset: goslim_chembl
+subset: goslim_generic
+subset: gosubset_prok
+synonym: "cellular nitrogen compound metabolism" EXACT []
+xref: Reactome:REACT_102000 "Metabolism of amino acids and derivatives, Mycobacterium tuberculosis"
+xref: Reactome:REACT_103710 "Metabolism of amino acids and derivatives, Escherichia coli"
+xref: Reactome:REACT_107293 "Metabolism of amino acids and derivatives, Arabidopsis thaliana"
+xref: Reactome:REACT_108179 "Metabolism of amino acids and derivatives, Xenopus tropicalis"
+xref: Reactome:REACT_109042 "Metabolism of amino acids and derivatives, Sus scrofa"
+xref: Reactome:REACT_13 "Metabolism of amino acids and derivatives, Homo sapiens"
+xref: Reactome:REACT_28699 "Metabolism of amino acids and derivatives, Saccharomyces cerevisiae"
+xref: Reactome:REACT_29108 "Metabolism of amino acids and derivatives, Caenorhabditis elegans"
+xref: Reactome:REACT_32429 "Metabolism of amino acids and derivatives, Rattus norvegicus"
+xref: Reactome:REACT_33347 "Metabolism of amino acids and derivatives, Mus musculus"
+xref: Reactome:REACT_34326 "Metabolism of amino acids and derivatives, Staphylococcus aureus N315"
+xref: Reactome:REACT_55564 "Metabolism of amino acids and derivatives, Gallus gallus"
+xref: Reactome:REACT_77741 "Metabolism of amino acids and derivatives, Taeniopygia guttata"
+xref: Reactome:REACT_82379 "Metabolism of amino acids and derivatives, Bos taurus"
+xref: Reactome:REACT_86268 "Metabolism of amino acids and derivatives, Drosophila melanogaster"
+xref: Reactome:REACT_90299 "Metabolism of amino acids and derivatives, Oryza sativa"
+xref: Reactome:REACT_91959 "Metabolism of amino acids and derivatives, Plasmodium falciparum"
+xref: Reactome:REACT_93580 "Metabolism of amino acids and derivatives, Danio rerio"
+xref: Reactome:REACT_95666 "Metabolism of amino acids and derivatives, Canis familiaris"
+xref: Reactome:REACT_98086 "Metabolism of amino acids and derivatives, Dictyostelium discoideum"
+xref: Reactome:REACT_99241 "Metabolism of amino acids and derivatives, Schizosaccharomyces pombe"
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0034655
+name: nucleobase-containing compound catabolic process
+namespace: biological_process
+def: "The chemical reactions and pathways resulting in the breakdown of nucleobases, nucleosides, nucleotides and nucleic acids." [GOC:mah]
+subset: goslim_chembl
+subset: goslim_generic
+subset: gosubset_prok
+synonym: "nucleobase, nucleoside, nucleotide and nucleic acid breakdown" EXACT []
+synonym: "nucleobase, nucleoside, nucleotide and nucleic acid catabolic process" RELATED [GOC:dph, GOC:tb]
+synonym: "nucleobase, nucleoside, nucleotide and nucleic acid catabolism" EXACT []
+synonym: "nucleobase, nucleoside, nucleotide and nucleic acid degradation" EXACT []
+is_a: GO:0009056 ! catabolic process
+is_a: GO:0034641 ! cellular nitrogen compound metabolic process
+
+[Term]
+id: GO:0040007
+name: growth
+namespace: biological_process
+alt_id: GO:0048590
+def: "The increase in size or mass of an entire organism, a part of an organism or a cell." [GOC:bf, GOC:ma]
+comment: See also the biological process term 'cell growth ; GO:0016049'.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_plant
+subset: gosubset_prok
+synonym: "growth pattern" RELATED []
+synonym: "non-developmental growth" RELATED [GOC:mah]
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0040011
+name: locomotion
+namespace: biological_process
+def: "Self-propelled movement of a cell or organism from one location to another." [GOC:dgh]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: gosubset_prok
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0042254
+name: ribosome biogenesis
+namespace: biological_process
+alt_id: GO:0007046
+def: "A cellular process that results in the biosynthesis of constituent macromolecules, assembly, and arrangement of constituent parts of ribosome subunits; includes transport to the sites of protein synthesis." [GOC:ma]
+subset: goslim_aspergillus
+subset: goslim_candida
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_pombe
+subset: gosubset_prok
+synonym: "ribosomal chaperone activity" RELATED []
+synonym: "ribosome biogenesis and assembly" EXACT []
+xref: Wikipedia:Ribosome_biogenesis
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0042393
+name: histone binding
+namespace: molecular_function
+def: "Interacting selectively and non-covalently with a histone, any of a group of water-soluble proteins found in association with the DNA of eukaroytic chromosomes. They are involved in the condensation and coiling of chromosomes during cell division and have also been implicated in nonspecific suppression of gene activity." [GOC:jl]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+synonym: "histone-specific chaperone activity" RELATED []
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0042592
+name: homeostatic process
+namespace: biological_process
+def: "Any biological process involved in the maintenance of an internal steady state." [GOC:jl, ISBN:0395825172]
+subset: goslim_agr
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_mouse
+subset: gosubset_prok
+synonym: "homeostasis" RELATED []
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0043167
+name: ion binding
+namespace: molecular_function
+def: "Interacting selectively and non-covalently with ions, charged atoms or groups of atoms." [GOC:jl]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "atom binding" RELATED []
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0043226
+name: organelle
+namespace: cellular_component
+def: "Organized structure of distinctive morphology and function. Includes the nucleus, mitochondria, plastids, vacuoles, vesicles, ribosomes and the cytoskeleton, and prokaryotic structures such as anammoxosomes and pirellulosomes. Excludes the plasma membrane." [GOC:go_curators]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: gosubset_prok
+xref: NIF_Subcellular:sao1539965131
+xref: Wikipedia:Organelle
+is_a: GO:0005575 ! cellular_component
+
+[Term]
+id: GO:0043234
+name: protein complex
+namespace: cellular_component
+def: "A stable macromolecular complex composed (only) of two or more polypeptide subunits along with any covalently attached molecules (such as lipid anchors or oligosaccharide) or non-protein prosthetic groups (such as nucleotides or metal ions). Prosthetic group in this context refers to a tightly bound cofactor. The component polypeptide subunits may be identical." [GOC:go_curators, http://www.ebi.ac.uk/intact/complex/documentation/]
+comment: A protein complex in this context is meant as a stable set of interacting proteins which can be co-purified by an acceptable method, and where the complex has been shown to exist as an isolated, functional unit in vivo. Acceptable experimental methods include stringent protein purification followed by detection of protein interaction. The following methods should be considered non-acceptable: simple immunoprecipitation, pull-down experiments from cell extracts without further purification, colocalization and 2-hybrid screening. Interactions that should not be captured as protein complexes include: 1) enzyme/substrate, receptor/ligand or any similar transient interactions, unless these are a critical part of the complex assembly or are required e.g. for the receptor to be functional; 2) proteins associated in a pull-down/co-immunoprecipitation assay with no functional link or any evidence that this is a defined biological entity rather than a loose-affinity complex; 3) any complex where the only evidence is based on genetic interaction data; 4) partial complexes, where some subunits (e.g. transmembrane ones) cannot be expressed as recombinant proteins and are excluded from experiments (in this case, independent evidence is necessary to find out the composition of the full complex, if known). Interactions that may be captured as protein complexes include: 1) enzyme/substrate or receptor/ligand if the complex can only assemble and become functional in the presence of both classes of subunits; 2) complexes where one of the members has not been shown to be physically linked to the other(s), but is a homologue of, and has the same functionality as, a protein that has been experimentally demonstrated to form a complex with the other member(s); 3) complexes whose existence is accepted based on localization and pharmacological studies, but for which experimental evidence is not yet available for the complex as a whole.
+subset: goslim_agr
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: gosubset_prok
+synonym: "protein-protein complex" EXACT []
+xref: Wikipedia:Protein_complex
+is_a: GO:0005575 ! cellular_component
+
+[Term]
+id: GO:0043473
+name: pigmentation
+namespace: biological_process
+def: "The accumulation of pigment in an organism, tissue or cell, either by increased deposition or by increased number of cells." [GOC:jl]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: gosubset_prok
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0044281
+name: small molecule metabolic process
+namespace: biological_process
+def: "The chemical reactions and pathways involving small molecules, any low molecular weight, monomeric, non-encoded molecule." [GOC:curators, GOC:pde, GOC:vw]
+comment: Small molecules in GO include monosaccharides but exclude disaccharides and polysaccharides.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+synonym: "small molecule metabolism" EXACT []
+xref: Reactome:REACT_111217 "Metabolism, Homo sapiens"
+xref: Reactome:REACT_112077 "Metabolism, Xenopus tropicalis"
+xref: Reactome:REACT_112140 "Metabolism, Dictyostelium discoideum"
+xref: Reactome:REACT_112621 "Metabolism, Mus musculus"
+xref: Reactome:REACT_112912 "Metabolism, Arabidopsis thaliana"
+xref: Reactome:REACT_113131 "Metabolism, Schizosaccharomyces pombe"
+xref: Reactome:REACT_113305 "Metabolism, Canis familiaris"
+xref: Reactome:REACT_113457 "Metabolism, Mycobacterium tuberculosis"
+xref: Reactome:REACT_113568 "Metabolism, Rattus norvegicus"
+xref: Reactome:REACT_113610 "Metabolism, Caenorhabditis elegans"
+xref: Reactome:REACT_113934 "Metabolism, Escherichia coli"
+xref: Reactome:REACT_114081 "Metabolism, Gallus gallus"
+xref: Reactome:REACT_114137 "Metabolism, Sus scrofa"
+xref: Reactome:REACT_114421 "Metabolism, Saccharomyces cerevisiae"
+xref: Reactome:REACT_114473 "Metabolism, Danio rerio"
+xref: Reactome:REACT_114495 "Metabolism, Staphylococcus aureus N315"
+xref: Reactome:REACT_114668 "Metabolism, Plasmodium falciparum"
+xref: Reactome:REACT_114983 "Metabolism, Drosophila melanogaster"
+xref: Reactome:REACT_115063 "Metabolism, Taeniopygia guttata"
+xref: Reactome:REACT_115388 "Metabolism, Oryza sativa"
+xref: Reactome:REACT_115420 "Metabolism, Bos taurus"
+xref: Reactome:REACT_115655 "Metabolism, Gallus gallus"
+is_a: GO:0008150 ! biological_process
+created_by: jane
+creation_date: 2010-01-26T12:05:20Z
+
+[Term]
+id: GO:0044403
+name: symbiosis, encompassing mutualism through parasitism
+namespace: biological_process
+alt_id: GO:0043298
+alt_id: GO:0044404
+def: "An interaction between two organisms living together in more or less intimate association. Microscopic symbionts are often referred to as endosymbionts. The various forms of symbiosis include parasitism, in which the association is disadvantageous or destructive to one of the organisms; mutualism, in which the association is advantageous, or often necessary to one or both and not harmful to either; and commensalism, in which one member of the association benefits while the other is not affected. However, mutualism, parasitism, and commensalism are often not discrete categories of interactions and should rather be perceived as a continuum of interaction ranging from parasitism to mutualism. In fact, the direction of a symbiotic interaction can change during the lifetime of the symbionts due to developmental changes as well as changes in the biotic/abiotic environment in which the interaction occurs." [GOC:cc, http://www.free-definition.com]
+comment: Note that this term encompasses all symbiotic relationships between species along a continuum from mutualism through to parasitism, as outlined in the definition.
+subset: goslim_chembl
+subset: goslim_generic
+subset: gosubset_prok
+synonym: "host-pathogen interaction" RELATED []
+synonym: "symbiosis" EXACT []
+synonym: "symbiotic interaction" EXACT []
+synonym: "symbiotic interaction between host and organism" RELATED []
+synonym: "symbiotic interaction between organisms" EXACT []
+synonym: "symbiotic interaction between species" EXACT []
+synonym: "symbiotic interaction with other non-host organism" RELATED []
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0048646
+name: anatomical structure formation involved in morphogenesis
+namespace: biological_process
+def: "The developmental process pertaining to the initial formation of an anatomical structure from unspecified parts. This process begins with the specific processes that contribute to the appearance of the discrete structure and ends when the structural rudiment is recognizable. An anatomical structure is any biological entity that occupies space and is distinguished from its surroundings. Anatomical structures can be macroscopic such as a carpel, or microscopic such as an acrosome." [GOC:dph, GOC:jid, GOC:tb]
+comment: Note that, for example, the formation of a pseudopod in an amoeba would not be considered formation involved in morphogenesis because it would not be thought of as the formation of an anatomical structure that was part of the shaping of the amoeba during its development. The formation of an axon from a neuron would be considered the formation of an anatomical structure involved in morphogenesis because it contributes to the creation of the form of the neuron in a developmental sense.
+subset: goslim_chembl
+subset: goslim_generic
+synonym: "formation of an anatomical structure involved in morphogenesis" EXACT [GOC:dph, GOC:tb]
+is_a: GO:0008150 ! biological_process
+relationship: part_of GO:0048856 ! anatomical structure development
+
+[Term]
+id: GO:0048856
+name: anatomical structure development
+namespace: biological_process
+def: "The biological process whose specific outcome is the progression of an anatomical structure from an initial condition to its mature state. This process begins with the formation of the structure and ends with the mature structure, whatever form that may be including its natural destruction. An anatomical structure is any biological entity that occupies space and is distinguished from its surroundings. Anatomical structures can be macroscopic such as a carpel, or microscopic such as an acrosome." [GO_REF:0000021, GOC:mtg_15jun06]
+comment: This term was added by GO_REF:0000021.
+subset: goslim_chembl
+subset: goslim_generic
+synonym: "development of an anatomical structure" EXACT []
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0048870
+name: cell motility
+namespace: biological_process
+def: "Any process involved in the controlled self-propelled movement of a cell that results in translocation of the cell from one place to another." [GOC:dgh, GOC:dph, GOC:isa_complete, GOC:mlg]
+subset: goslim_chembl
+subset: goslim_generic
+subset: gosubset_prok
+synonym: "cell locomotion" EXACT []
+synonym: "cell movement" RELATED []
+synonym: "movement of a cell" EXACT []
+is_a: GO:0040011 ! locomotion
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0050877
+name: nervous system process
+namespace: biological_process
+def: "A organ system process carried out by any of the organs or tissues of neurological system." [GOC:ai, GOC:mtg_cardio]
+comment: Discussion of class label and synonyms: https://github.com/geneontology/go-ontology/issues/13824
+subset: goslim_agr
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+synonym: "neurological system process" EXACT []
+synonym: "neurophysiological process" EXACT []
+synonym: "pan-neural process" RELATED []
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0051082
+name: unfolded protein binding
+namespace: molecular_function
+def: "Interacting selectively and non-covalently with an unfolded protein." [GOC:ai]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "binding unfolded ER proteins" NARROW []
+synonym: "chaperone activity" RELATED []
+synonym: "fimbrium-specific chaperone activity" RELATED []
+synonym: "glycoprotein-specific chaperone activity" RELATED []
+synonym: "histone-specific chaperone activity" RELATED []
+synonym: "ribosomal chaperone activity" RELATED []
+synonym: "tubulin-specific chaperone activity" RELATED []
+is_a: GO:0003674 ! molecular_function
+
+[Term]
+id: GO:0051186
+name: cofactor metabolic process
+namespace: biological_process
+def: "The chemical reactions and pathways involving a cofactor, a substance that is required for the activity of an enzyme or other protein. Cofactors may be inorganic, such as the metal atoms zinc, iron, and copper in certain forms, or organic, in which case they are referred to as coenzymes. Cofactors may either be bound tightly to active sites or bind loosely with the substrate." [GOC:ai]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_pombe
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "cofactor metabolism" EXACT []
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0051276
+name: chromosome organization
+namespace: biological_process
+alt_id: GO:0007001
+alt_id: GO:0051277
+def: "A process that is carried out at the cellular level that results in the assembly, arrangement of constituent parts, or disassembly of chromosomes, structures composed of a very long molecule of DNA and associated proteins that carries hereditary information. This term covers covalent modifications at the molecular level as well as spatial relationships among the major components of a chromosome." [GOC:ai, GOC:dph, GOC:jl, GOC:mah]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: gosubset_prok
+synonym: "chromosome organisation" EXACT []
+synonym: "chromosome organization and biogenesis" RELATED [GOC:mah]
+synonym: "maintenance of genome integrity" RELATED []
+synonym: "nuclear genome maintenance" RELATED []
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0051301
+name: cell division
+namespace: biological_process
+def: "The process resulting in division and partitioning of components of a cell to form more cells; may or may not be accompanied by the physical separation of a cell into distinct, individually membrane-bounded daughter cells." [GOC:di, GOC:go_curators, GOC:pr]
+comment: Note that this term differs from 'cytokinesis ; GO:0000910' in that cytokinesis does not include nuclear division.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: gosubset_prok
+xref: Wikipedia:Cell_division
+is_a: GO:0008150 ! biological_process
+
+[Term]
+id: GO:0051604
+name: protein maturation
+namespace: biological_process
+def: "Any process leading to the attainment of the full functional capacity of a protein." [GOC:ai]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pir
+subset: goslim_pombe
+subset: goslim_yeast
+subset: gosubset_prok
+is_a: GO:0008150 ! biological_process
+relationship: part_of GO:0008150 ! biological_process
+
+[Term]
+id: GO:0055085
+name: transmembrane transport
+namespace: biological_process
+def: "The process in which a solute is transported across a lipid bilayer, from one side of a membrane to the other" [GOC:dph, GOC:jid]
+comment: Transmembrane transport requires transport of a solute across a lipid bilayer. Note that transport through the nuclear pore complex is not transmembrane because the nuclear membrane is a double membrane and is not traversed. For transport through the nuclear pore, consider instead the term 'nucleocytoplasmic transport ; GO:0006913' and its children. Note also that this term is not intended for use in annotating lateral movement within membranes.
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pombe
+subset: goslim_yeast
+synonym: "membrane transport" EXACT []
+xref: Reactome:REACT_100480 "SLC-mediated transmembrane transport, Taeniopygia guttata"
+xref: Reactome:REACT_101577 "SLC-mediated transmembrane transport, Caenorhabditis elegans"
+xref: Reactome:REACT_101877 "SLC-mediated transmembrane transport, Escherichia coli"
+xref: Reactome:REACT_101975 "SLC-mediated transmembrane transport, Sus scrofa"
+xref: Reactome:REACT_102348 "Transmembrane transport of small molecules, Staphylococcus aureus N315"
+xref: Reactome:REACT_102897 "Transmembrane transport of small molecules, Caenorhabditis elegans"
+xref: Reactome:REACT_102974 "SLC-mediated transmembrane transport, Canis familiaris"
+xref: Reactome:REACT_104555 "SLC-mediated transmembrane transport, Xenopus tropicalis"
+xref: Reactome:REACT_108243 "SLC-mediated transmembrane transport, Staphylococcus aureus N315"
+xref: Reactome:REACT_109832 "Transmembrane transport of small molecules, Plasmodium falciparum"
+xref: Reactome:REACT_110770 "ABC-family proteins mediated transport, Mus musculus"
+xref: Reactome:REACT_114546 "ABC-family proteins mediated transport, Staphylococcus aureus N315"
+xref: Reactome:REACT_114763 "ABC-family proteins mediated transport, Escherichia coli"
+xref: Reactome:REACT_114890 "ABC-family proteins mediated transport, Plasmodium falciparum"
+xref: Reactome:REACT_115378 "ABC-family proteins mediated transport, Mycobacterium tuberculosis"
+xref: Reactome:REACT_15480 "ABC-family proteins mediated transport, Homo sapiens"
+xref: Reactome:REACT_15518 "Transmembrane transport of small molecules, Homo sapiens"
+xref: Reactome:REACT_19118 "SLC-mediated transmembrane transport, Homo sapiens"
+xref: Reactome:REACT_29093 "ABC-family proteins mediated transport, Taeniopygia guttata"
+xref: Reactome:REACT_29184 "SLC-mediated transmembrane transport, Gallus gallus"
+xref: Reactome:REACT_29635 "Transmembrane transport of small molecules, Canis familiaris"
+xref: Reactome:REACT_30969 "ABC-family proteins mediated transport, Canis familiaris"
+xref: Reactome:REACT_32055 "Transmembrane transport of small molecules, Saccharomyces cerevisiae"
+xref: Reactome:REACT_32223 "Transmembrane transport of small molecules, Rattus norvegicus"
+xref: Reactome:REACT_32423 "SLC-mediated transmembrane transport, Bos taurus"
+xref: Reactome:REACT_32713 "ABC-family proteins mediated transport, Sus scrofa"
+xref: Reactome:REACT_33571 "SLC-mediated transmembrane transport, Danio rerio"
+xref: Reactome:REACT_61245 "Transmembrane transport of small molecules, Bos taurus"
+xref: Reactome:REACT_79086 "SLC-mediated transmembrane transport, Plasmodium falciparum"
+xref: Reactome:REACT_79921 "SLC-mediated transmembrane transport, Saccharomyces cerevisiae"
+xref: Reactome:REACT_80022 "ABC-family proteins mediated transport, Bos taurus"
+xref: Reactome:REACT_80510 "ABC-family proteins mediated transport, Rattus norvegicus"
+xref: Reactome:REACT_80848 "ABC-family proteins mediated transport, Schizosaccharomyces pombe"
+xref: Reactome:REACT_80977 "ABC-family proteins mediated transport, Caenorhabditis elegans"
+xref: Reactome:REACT_81024 "Transmembrane transport of small molecules, Oryza sativa"
+xref: Reactome:REACT_81153 "SLC-mediated transmembrane transport, Mus musculus"
+xref: Reactome:REACT_82725 "SLC-mediated transmembrane transport, Rattus norvegicus"
+xref: Reactome:REACT_83770 "Transmembrane transport of small molecules, Escherichia coli"
+xref: Reactome:REACT_86135 "ABC-family proteins mediated transport, Oryza sativa"
+xref: Reactome:REACT_86409 "Transmembrane transport of small molecules, Drosophila melanogaster"
+xref: Reactome:REACT_86576 "Transmembrane transport of small molecules, Schizosaccharomyces pombe"
+xref: Reactome:REACT_87124 "SLC-mediated transmembrane transport, Oryza sativa"
+xref: Reactome:REACT_88059 "ABC-family proteins mediated transport, Xenopus tropicalis"
+xref: Reactome:REACT_88521 "Transmembrane transport of small molecules, Taeniopygia guttata"
+xref: Reactome:REACT_88894 "Transmembrane transport of small molecules, Gallus gallus"
+xref: Reactome:REACT_89376 "SLC-mediated transmembrane transport, Schizosaccharomyces pombe"
+xref: Reactome:REACT_91272 "ABC-family proteins mediated transport, Arabidopsis thaliana"
+xref: Reactome:REACT_91803 "SLC-mediated transmembrane transport, Mycobacterium tuberculosis"
+xref: Reactome:REACT_92006 "Transmembrane transport of small molecules, Mycobacterium tuberculosis"
+xref: Reactome:REACT_92624 "ABC-family proteins mediated transport, Gallus gallus"
+xref: Reactome:REACT_93747 "Transmembrane transport of small molecules, Dictyostelium discoideum"
+xref: Reactome:REACT_94160 "Transmembrane transport of small molecules, Mus musculus"
+xref: Reactome:REACT_94393 "ABC-family proteins mediated transport, Drosophila melanogaster"
+xref: Reactome:REACT_94944 "ABC-family proteins mediated transport, Danio rerio"
+xref: Reactome:REACT_94972 "SLC-mediated transmembrane transport, Dictyostelium discoideum"
+xref: Reactome:REACT_96633 "Transmembrane transport of small molecules, Sus scrofa"
+xref: Reactome:REACT_96636 "SLC-mediated transmembrane transport, Arabidopsis thaliana"
+xref: Reactome:REACT_97365 "Transmembrane transport of small molecules, Arabidopsis thaliana"
+xref: Reactome:REACT_97867 "ABC-family proteins mediated transport, Saccharomyces cerevisiae"
+xref: Reactome:REACT_98509 "Transmembrane transport of small molecules, Xenopus tropicalis"
+xref: Reactome:REACT_98716 "SLC-mediated transmembrane transport, Drosophila melanogaster"
+xref: Reactome:REACT_99579 "Transmembrane transport of small molecules, Danio rerio"
+xref: Reactome:REACT_99829 "ABC-family proteins mediated transport, Dictyostelium discoideum"
+is_a: GO:0006810 ! transport
+
+[Term]
+id: GO:0061024
+name: membrane organization
+namespace: biological_process
+alt_id: GO:0016044
+alt_id: GO:0044802
+def: "A process which results in the assembly, arrangement of constituent parts, or disassembly of a membrane. A membrane is a double layer of lipid molecules that encloses all cells, and, in eukaryotes, many organelles; may be a single or double lipid bilayer; also includes associated proteins." [GOC:dph, GOC:tb]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pombe
+synonym: "cellular membrane organisation" EXACT [GOC:curators]
+synonym: "cellular membrane organization" EXACT []
+synonym: "membrane organisation" EXACT [GOC:mah]
+synonym: "membrane organization and biogenesis" RELATED [GOC:mah]
+synonym: "single-organism membrane organization" RELATED []
+xref: Reactome:REACT_101524 "Membrane Trafficking, Dictyostelium discoideum"
+xref: Reactome:REACT_103082 "Membrane Trafficking, Schizosaccharomyces pombe"
+xref: Reactome:REACT_11123 "Membrane Trafficking, Homo sapiens"
+xref: Reactome:REACT_29278 "Membrane Trafficking, Sus scrofa"
+xref: Reactome:REACT_32337 "Membrane Trafficking, Taeniopygia guttata"
+xref: Reactome:REACT_33741 "Membrane Trafficking, Bos taurus"
+xref: Reactome:REACT_34084 "Membrane Trafficking, Caenorhabditis elegans"
+xref: Reactome:REACT_78213 "Membrane Trafficking, Plasmodium falciparum"
+xref: Reactome:REACT_78288 "Membrane Trafficking, Xenopus tropicalis"
+xref: Reactome:REACT_83546 "Membrane Trafficking, Oryza sativa"
+xref: Reactome:REACT_86557 "Membrane Trafficking, Arabidopsis thaliana"
+xref: Reactome:REACT_87431 "Membrane Trafficking, Drosophila melanogaster"
+xref: Reactome:REACT_88307 "Membrane Trafficking, Mus musculus"
+xref: Reactome:REACT_91154 "Membrane Trafficking, Saccharomyces cerevisiae"
+xref: Reactome:REACT_93714 "Membrane Trafficking, Danio rerio"
+xref: Reactome:REACT_95586 "Membrane Trafficking, Gallus gallus"
+xref: Reactome:REACT_96516 "Membrane Trafficking, Canis familiaris"
+xref: Reactome:REACT_97881 "Membrane Trafficking, Rattus norvegicus"
+is_a: GO:0008150 ! biological_process
+created_by: janelomax
+creation_date: 2010-02-08T02:43:11Z
+
+[Term]
+id: GO:0065003
+name: macromolecular complex assembly
+namespace: biological_process
+def: "The aggregation, arrangement and bonding together of a set of macromolecules to form a complex." [GOC:jl]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_metagenomics
+subset: goslim_pir
+subset: gosubset_prok
+synonym: "macromolecule complex assembly" EXACT []
+is_a: GO:0022607 ! cellular component assembly
+
+[Term]
+id: GO:0071554
+name: cell wall organization or biogenesis
+namespace: biological_process
+alt_id: GO:0070882
+def: "A process that results in the biosynthesis of constituent macromolecules, assembly, arrangement of constituent parts, or disassembly of a cell wall." [GOC:mah]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pombe
+subset: goslim_yeast
+subset: gosubset_prok
+synonym: "cell wall organisation or biogenesis" EXACT [GOC:mah]
+synonym: "cell wall organization or biogenesis at cellular level" EXACT [GOC:mah]
+synonym: "cellular cell wall organisation or biogenesis" EXACT [GOC:mah]
+synonym: "cellular cell wall organization or biogenesis" EXACT []
+is_a: GO:0008150 ! biological_process
+created_by: midori
+creation_date: 2010-01-13T03:19:38Z
+
+[Term]
+id: GO:0071941
+name: nitrogen cycle metabolic process
+namespace: biological_process
+def: "A nitrogen compound metabolic process that contributes to the nitrogen cycle. The nitrogen cycle is a series of metabolic pathways by which nitrogen is converted between various forms and redox states; it encompasses pathways in which nitrogen is acted upon directly, such as nitrification, denitrification, nitrogen fixation, and mineralization." [GOC:mah, PMID:16675690, Wikipedia:Nitrogen_cycle]
+subset: goslim_chembl
+subset: goslim_generic
+subset: goslim_pombe
+xref: Wikipedia:Nitrogen_cycle
+is_a: GO:0008150 ! biological_process
+created_by: midori
+creation_date: 2010-09-30T05:21:03Z
+
+[Term]
+id: GO:0140014
+name: mitotic nuclear division
+namespace: biological_process
+def: "A mitotic cell cycle process comprising the steps by which the nucleus of a eukaryotic cell divides; the process involves condensation of chromosomal DNA into a highly compacted form. Canonically, mitosis produces two daughter nuclei whose chromosome complement is identical to that of the mother cell." [ISBN:0198547684]
+subset: goslim_chembl
+subset: goslim_generic
+is_a: GO:0008150 ! biological_process
+relationship: part_of GO:0000278 ! mitotic cell cycle
+created_by: pg
+creation_date: 2017-03-23T14:44:23Z
+
+[Typedef]
+id: ends_during
+name: ends_during
+namespace: external
+xref: RO:0002093
+
+[Typedef]
+id: happens_during
+name: happens_during
+namespace: external
+xref: RO:0002092
+is_transitive: true
+is_a: ends_during ! ends_during
+
+[Typedef]
+id: has_part
+name: has_part
+namespace: external
+xref: BFO:0000051
+is_transitive: true
+
+[Typedef]
+id: negatively_regulates
+name: negatively regulates
+namespace: external
+xref: RO:0002212
+is_a: regulates ! regulates
+transitive_over: part_of ! part of
+
+[Typedef]
+id: never_in_taxon
+name: never_in_taxon
+namespace: external
+xref: RO:0002161
+expand_assertion_to: "Class: ?X DisjointWith: RO_0002162 some ?Y" []
+is_metadata_tag: true
+is_class_level: true
+
+[Typedef]
+id: occurs_in
+name: occurs in
+namespace: external
+xref: BFO:0000066
+holds_over_chain: part_of occurs_in
+transitive_over: part_of ! part of
+
+[Typedef]
+id: part_of
+name: part of
+namespace: external
+xref: BFO:0000050
+is_transitive: true
+inverse_of: has_part ! has_part
+
+[Typedef]
+id: positively_regulates
+name: positively regulates
+namespace: external
+xref: RO:0002213
+holds_over_chain: negatively_regulates negatively_regulates
+is_a: regulates ! regulates
+transitive_over: part_of ! part of
+
+[Typedef]
+id: regulates
+name: regulates
+namespace: external
+xref: RO:0002211
+is_transitive: true
+transitive_over: part_of ! part of
+
+[Typedef]
+id: starts_during
+name: starts_during
+namespace: external
+xref: RO:0002091
+

--- a/goenrich/tests/test_reading.py
+++ b/goenrich/tests/test_reading.py
@@ -1,3 +1,4 @@
+import pkg_resources
 import unittest
 import gzip
 import goenrich
@@ -26,6 +27,12 @@ class TestRead(unittest.TestCase):
         with gzip.GzipFile('db/gene2go.gz') as f:
             background = goenrich.read.gene2go(f)
             self.assertFalse(f.closed)
+
+    def test_goslim_from_file(self):
+        G = goenrich.obo.ontology(pkg_resources.resource_filename(goenrich.__name__, 'tests/test_ontologies/goslim_generic.obo'))
+        self.assertEqual(len(G.nodes()), 150)
+        self.assertSetEqual(set(G.successors('GO:0009056')), set(['GO:0008150']))
+        self.assertSetEqual(set(G.predecessors('GO:0009056')), set(['GO:0034655', 'GO:0006914']))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Two changes in Networkx 2.0 API had problems:
1. G.reverse doesn't do in-place reverse in 2.0 even with copy=False
2. G.node[n] returns a Nodeview which doesn't allow assignment of the attributes.

Also added additional strict tests. Previous tests didn't detect problems even when the results of enrichment were wrong. Now explicitly compute number of significantly enriched categories and compare with reference results.

Additional test for reading uses a small ontology subset (goslim_generic)  which I included as a package resource. It is useful because it doesn't require any downloads from servers to run this test. 
