### PR TITLE
Update for networkx 2.3 --> 2.4, minor safety fixes in obo.py

### DIFF
--- a/goenrich/enrich.py
+++ b/goenrich/enrich.py
@@ -47,7 +47,7 @@ def analyze(O, query, background_attribute, **kwargs):
         G = induced_subgraph(O, sig)
         for term, node, q, x, n, rej in zip(terms, nodes, qs, xs, ns, rejs):
             if term in G:
-                G.node[term].update({'name' : node['name'], 'x' : x,
+                G.nodes[term].update({'name' : node['name'], 'x' : x,
                     'q' : q, 'n' : n, 'significant' : rej})
         goenrich.export.to_graphviz(G.reverse(copy=False), **options)
     return df
@@ -114,10 +114,10 @@ def propagate(O, values, attribute):
     :param attribute: name of the attribute
     """
     for n in nx.topological_sort(O):
-        current = O.node[n].setdefault(attribute, set())
+        current = O.nodes[n].setdefault(attribute, set())
         current.update(values.get(n, set()))
         for p in O[n]:
-            O.node[p].setdefault(attribute, set()).update(current)
+            O.nodes[p].setdefault(attribute, set()).update(current)
 
 def induced_subgraph(O, terms):
     """  Extracts a subgraph from O including the provided terms

--- a/goenrich/enrich.py
+++ b/goenrich/enrich.py
@@ -3,10 +3,10 @@ import numpy as np
 from scipy.stats import hypergeom
 import networkx as nx
 nx_version = list(map(int, nx.__version__.split('.')))
-if nx_version[0] <= 2 and nx_version[1] < 4:
+if nx_version[0] >= 2 and nx_version[1] >= 4:
     nx.Graph.node = nx.Graph.nodes
-
 from goenrich.tools import fdrcorrection
+
 import goenrich.export
 
 def analyze(O, query, background_attribute, **kwargs):

--- a/goenrich/enrich.py
+++ b/goenrich/enrich.py
@@ -1,9 +1,12 @@
 import random
-import networkx as nx
 import numpy as np
 from scipy.stats import hypergeom
-from goenrich.tools import fdrcorrection
+import networkx as nx
+nx_version = list(map(int, nx.__version__.split('.')))
+if nx_version[0] <= 2 and nx_version[1] < 4:
+    nx.Graph.node = nx.Graph.nodes
 
+from goenrich.tools import fdrcorrection
 import goenrich.export
 
 def analyze(O, query, background_attribute, **kwargs):

--- a/goenrich/export.py
+++ b/goenrich/export.py
@@ -29,7 +29,7 @@ def to_graphviz(G, gvfile, graph_label='', **kwargs):
     :param graph_label: For empty label pass graph_label=''.
     """
     for n in G:
-        node = G.node[n]
+        node = G.nodes[n]
         attr = {}
         attr['shape'] = 'record'
         if not np.isnan(node.get('q', float('NaN'))):
@@ -39,8 +39,8 @@ def to_graphviz(G, gvfile, graph_label='', **kwargs):
         else:
             attr['color'] = 'black'
             attr['label'] = """{name}""".format(name=node['name'])
-        G.node[n].clear()
-        G.node[n].update(attr)
+        G.nodes[n].clear()
+        G.nodes[n].update(attr)
 
     A = nx.drawing.nx_agraph.to_agraph(G)
     A.graph_attr['label'] = graph_label

--- a/goenrich/export.py
+++ b/goenrich/export.py
@@ -1,6 +1,9 @@
-import networkx as nx
 import numpy as np
 import pandas as pd
+import networkx as nx
+nx_version = list(map(int, nx.__version__.split('.')))
+if nx_version[0] <= 2 and nx_version[1] < 4:
+    nx.Graph.node = nx.Graph.nodes
 
 import goenrich
 

--- a/goenrich/export.py
+++ b/goenrich/export.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import networkx as nx
 nx_version = list(map(int, nx.__version__.split('.')))
-if nx_version[0] <= 2 and nx_version[1] < 4:
+if nx_version[0] >= 2 and nx_version[1] >= 4:
     nx.Graph.node = nx.Graph.nodes
 
 import goenrich

--- a/goenrich/obo.py
+++ b/goenrich/obo.py
@@ -48,28 +48,20 @@ def ontology(file):
     """
     O = nx.DiGraph()
 
-    if isinstance(file, str):
-        f = open(file)
-        we_opened_file = True
-    else:
-        f = file
-        we_opened_file = False
-
-    try:
-        tokens = _tokenize(f)
-        terms = _filter_terms(tokens)
-        entries = _parse_terms(terms)
-        nodes, edges = zip(*entries)
-        O.add_nodes_from(nodes)
-        O.add_edges_from(itertools.chain.from_iterable(edges))
-        O.graph['roots'] = {data['name'] : n for n, data in O.node.items()
-                if data['name'] == data['namespace']}
-    finally:
-        if we_opened_file:
-            f.close()
+    with open(file, 'r') as f:
+        tokens = list(_tokenize(f))
+    
+    terms = _filter_terms(tokens)
+    entries = _parse_terms(terms)
+    nodes, edges = zip(*entries)
+    O.add_nodes_from(nodes)
+    O.add_edges_from(itertools.chain.from_iterable(edges))
+    O.graph['roots'] = {data['name'] : n for n, data in O.nodes.items()
+            if data['name'] == data['namespace']}
+    
 
     for root in O.graph['roots'].values():
         for n, depth in nx.shortest_path_length(O, root).items():
-            node = O.node[n]
+            node = O.nodes[n]
             node['depth'] = min(depth, node.get('depth', float('inf')))
     return O.reverse()

--- a/goenrich/obo.py
+++ b/goenrich/obo.py
@@ -1,5 +1,8 @@
 import itertools
 import networkx as nx
+nx_version = list(map(int, nx.__version__.split('.')))
+if nx_version[0] <= 2 and nx_version[1] < 4:
+    nx.Graph.node = nx.Graph.nodes
 
 def _tokenize(f):
     token = []

--- a/goenrich/tests/test_enrichment.py
+++ b/goenrich/tests/test_enrichment.py
@@ -1,7 +1,11 @@
 import unittest
 import subprocess
 import goenrich
-import networkx
+import networkx as nx
+nx_version = list(map(int, nx.__version__.split('.')))
+if nx_version[0] >= 2 and nx_version[1] >= 4:
+    nx.Graph.node = nx.Graph.nodes
+networkx = nx
 
 class TestGoenrich(unittest.TestCase):
 

--- a/goenrich/tests/test_propagation.py
+++ b/goenrich/tests/test_propagation.py
@@ -1,5 +1,8 @@
 import unittest
 import networkx as nx
+nx_version = list(map(int, nx.__version__.split('.')))
+if nx_version[0] >= 2 and nx_version[1] >= 4:
+    nx.Graph.node = nx.Graph.nodes
 import pandas as pd
 import goenrich
 from goenrich.enrich import propagate

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 setup(name='goenrich',
       version='1.11',
       description='GO enrichment with python -- pandas meets networkx',
-      long_description=readme(),
+      long_description="",
       classifiers=[
           'Development Status :: 4 - Beta',
           'Intended Audience :: Science/Research',


### PR DESCRIPTION
== Update for NetworkX 2.3 --> 2.4 ==

As per the release notes for NetworkX2.4 (https://networkx.github.io/documentation/stable/release/release_2.4.html#deprecations)

G.node –> use G.nodes

The nx.Graph class's .node attribute is depreciated in favour of the .nodes attribute (which was in previous versions of NetworkX). No changes in functionality though. 

Changes: All <DiGraph>.node calls were replaced with <DiGraph>.nodes.

== minor file IO safety fix ==

The ontology function in goenrich/obo.py had non-descript behaviour for inputs being non-file path strings. It also delayed the _io.TextIOWrapper.close() call, which seemed unintentionally/unnecessarily risky.

Changes: f = open(file) and calling f.close() in goenrich/obo.py were replaced with the safer context-manager way (with open(file, mode) as f:...). Also replaced 

else:
        f = file
        we_opened_file = False