### PR TITLE
Compatibility with `networkx` v2.4, changing every use of the `.node` method to `.nodes`.

### DIFF
--- a/goenrich/enrich.py
+++ b/goenrich/enrich.py
@@ -47,7 +47,7 @@ def analyze(O, query, background_attribute, **kwargs):
         G = induced_subgraph(O, sig)
         for term, node, q, x, n, rej in zip(terms, nodes, qs, xs, ns, rejs):
             if term in G:
-                G.node[term].update({'name' : node['name'], 'x' : x,
+                G.nodes[term].update({'name' : node['name'], 'x' : x,
                     'q' : q, 'n' : n, 'significant' : rej})
         goenrich.export.to_graphviz(G.reverse(copy=False), **options)
     return df
@@ -114,10 +114,10 @@ def propagate(O, values, attribute):
     :param attribute: name of the attribute
     """
     for n in nx.topological_sort(O):
-        current = O.node[n].setdefault(attribute, set())
+        current = O.nodes[n].setdefault(attribute, set())
         current.update(values.get(n, set()))
         for p in O[n]:
-            O.node[p].setdefault(attribute, set()).update(current)
+            O.nodes[p].setdefault(attribute, set()).update(current)
 
 def induced_subgraph(O, terms):
     """  Extracts a subgraph from O including the provided terms

--- a/goenrich/export.py
+++ b/goenrich/export.py
@@ -29,7 +29,7 @@ def to_graphviz(G, gvfile, graph_label='', **kwargs):
     :param graph_label: For empty label pass graph_label=''.
     """
     for n in G:
-        node = G.node[n]
+        node = G.nodes[n]
         attr = {}
         attr['shape'] = 'record'
         if not np.isnan(node.get('q', float('NaN'))):
@@ -39,8 +39,8 @@ def to_graphviz(G, gvfile, graph_label='', **kwargs):
         else:
             attr['color'] = 'black'
             attr['label'] = """{name}""".format(name=node['name'])
-        G.node[n].clear()
-        G.node[n].update(attr)
+        G.nodes[n].clear()
+        G.nodes[n].update(attr)
 
     A = nx.drawing.nx_agraph.to_agraph(G)
     A.graph_attr['label'] = graph_label

--- a/goenrich/obo.py
+++ b/goenrich/obo.py
@@ -62,7 +62,7 @@ def ontology(file):
         nodes, edges = zip(*entries)
         O.add_nodes_from(nodes)
         O.add_edges_from(itertools.chain.from_iterable(edges))
-        O.graph['roots'] = {data['name'] : n for n, data in O.node.items()
+        O.graph['roots'] = {data['name'] : n for n, data in O.nodes.items()
                 if data['name'] == data['namespace']}
     finally:
         if we_opened_file:
@@ -70,6 +70,6 @@ def ontology(file):
 
     for root in O.graph['roots'].values():
         for n, depth in nx.shortest_path_length(O, root).items():
-            node = O.node[n]
+            node = O.nodes[n]
             node['depth'] = min(depth, node.get('depth', float('inf')))
     return O.reverse()

--- a/goenrich/tests/test_propagation.py
+++ b/goenrich/tests/test_propagation.py
@@ -28,10 +28,10 @@ class TestPropagationExample(unittest.TestCase):
         b = 'background'
         propagate(O, x, b)
 
-        self.assertSetEqual(O.node['c3'][b], c3)
-        self.assertSetEqual(O.node['c2'][b], c4 | c3 | c2)
-        self.assertSetEqual(O.node['c1'][b], c3 | c1)
-        self.assertSetEqual(O.node['r'][b], c4 | c3 | c2 | c1 | r)
+        self.assertSetEqual(O.nodes['c3'][b], c3)
+        self.assertSetEqual(O.nodes['c2'][b], c4 | c3 | c2)
+        self.assertSetEqual(O.nodes['c1'][b], c3 | c1)
+        self.assertSetEqual(O.nodes['r'][b], c4 | c3 | c2 | c1 | r)
 
 class TestPropagationReal(unittest.TestCase):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
As pointed out in #14 and probably addressed in #15 , this is just changing every `.node` to `.nodes`. This pull request is just that, without some of the other more extensive modifications in #15 .

This works with `networkx` v2.4 (nicely!).

I'm new to pull requests, so let me know if I should provide you with anything else, other testing, etc.